### PR TITLE
Add native Ollama provider

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -369,6 +369,7 @@ set(AGENTTY_AIRGAP_SOURCES
 set(AGENTTY_PROVIDER_SOURCES
     src/provider/anthropic/transport.cpp
     src/provider/openai/transport.cpp
+    src/provider/ollama/transport.cpp
     src/provider/selection.cpp
 )
 
@@ -1158,6 +1159,44 @@ if(AGENTTY_BUILD_TESTS)
     endif()
     add_test(NAME openai_transport_test COMMAND openai_transport_test)
 
+    # ollama_transport_test — verifies the DEDICATED Ollama /api/chat
+    # transport: native build_messages (object-form tool args + role:tool
+    # results + images), NDJSON parse (structured tool_calls, plain text,
+    # NO content-salvage, error frames), and the local system prompt shape.
+    add_executable(ollama_transport_test EXCLUDE_FROM_ALL
+        tests/ollama_transport_test.cpp
+        ${AGENTTY_IO_SOURCES}
+        ${AGENTTY_WORKSPACE_SOURCES}
+        ${AGENTTY_AIRGAP_SOURCES}
+        ${AGENTTY_PROVIDER_SOURCES}
+        ${AGENTTY_DIFF_SOURCES}
+        ${AGENTTY_TOOL_SOURCES}
+        ${AGENTTY_RUNTIME_NOMAIN_SOURCES}
+    )
+    target_include_directories(ollama_transport_test PRIVATE include)
+    target_compile_definitions(ollama_transport_test PRIVATE
+        AGENTTY_VERSION="${PROJECT_VERSION}")
+    target_link_libraries(ollama_transport_test PRIVATE
+        maya::maya
+        nlohmann_json::nlohmann_json
+        simdjson::simdjson
+        nghttp2::nghttp2
+        OpenSSL::SSL
+        OpenSSL::Crypto
+        Threads::Threads
+    )
+    if(WIN32)
+        target_link_libraries(ollama_transport_test PRIVATE
+            ws2_32 crypt32 shell32 winmm
+            user32 gdi32 gdiplus shlwapi)
+    endif()
+    if(APPLE)
+        target_link_libraries(ollama_transport_test PRIVATE
+            "-framework Security"
+            "-framework CoreFoundation")
+    endif()
+    add_test(NAME ollama_transport_test COMMAND ollama_transport_test)
+
     # visual_hash_coverage_test — proves the render gate
     # (Program::visual_hash) can't silently drop a visible change. Two
     # declarative tables: every view-affecting model axis must advance
@@ -1455,6 +1494,7 @@ if(AGENTTY_BUILD_TESTS)
         stream_liveness_test
         table_render_test
         openai_transport_test
+        ollama_transport_test
         visual_hash_coverage_test
         tool_result_budget_test
         salvage_dedup_test

--- a/include/agentty/domain/catalog.hpp
+++ b/include/agentty/domain/catalog.hpp
@@ -211,9 +211,6 @@ private:
             if (v > params_b) params_b = v;       // take the largest match
         }
 
-        // Large models follow tool schemas reliably regardless of family.
-        if (params_b >= 14) return false;
-
         // Tool-trained / instruction-strong local families → strong even at
         // smaller sizes.
         const bool strong_family =
@@ -241,6 +238,9 @@ private:
             contains(id, "smollm")       || contains(id, "codegemma")  ||
             contains(id, "sqlcoder");
         if (weak_family) return true;
+
+        // Large models (no weak-family signal) follow tool schemas reliably.
+        if (params_b >= 14) return false;
 
         // No family signal: rely on size. <= 8B → weak; otherwise assume the
         // model (or hosted endpoint, unknown id) is capable.

--- a/include/agentty/provider/ollama/provider.hpp
+++ b/include/agentty/provider/ollama/provider.hpp
@@ -1,20 +1,20 @@
 #pragma once
-// agentty::provider::openai::OpenAIProvider — concrete adapter satisfying the
+// agentty::provider::ollama::OllamaProvider — concrete adapter satisfying the
 // `provider::Provider` concept by translating the abstract request into an
-// openai::transport call. Holds an Endpoint (base URL / port / tls) so one
-// process can target OpenAI, Groq, OpenRouter, a local Ollama, etc.
+// ollama::transport /api/chat call. Holds the Endpoint (host/port) of the
+// local Ollama server.
 
 #include <utility>
 
 #include "agentty/provider/provider.hpp"
-#include "agentty/provider/openai/transport.hpp"
+#include "agentty/provider/ollama/transport.hpp"
 
-namespace agentty::provider::openai {
+namespace agentty::provider::ollama {
 
-class OpenAIProvider {
+class OllamaProvider {
 public:
-    OpenAIProvider() = default;
-    explicit OpenAIProvider(Endpoint endpoint) : endpoint_(std::move(endpoint)) {}
+    OllamaProvider() = default;
+    explicit OllamaProvider(Endpoint endpoint) : endpoint_(std::move(endpoint)) {}
 
     void stream(provider::Request req, provider::EventSink sink) {
         Request oreq;
@@ -26,7 +26,7 @@ public:
         oreq.auth          = std::move(req.auth);
         oreq.retry_count   = req.retry_count;
         oreq.endpoint      = endpoint_;
-        openai::run_stream_sync(std::move(oreq), std::move(sink), std::move(req.cancel));
+        ollama::run_stream_sync(std::move(oreq), std::move(sink), std::move(req.cancel));
     }
 
     [[nodiscard]] const Endpoint& endpoint() const noexcept { return endpoint_; }
@@ -35,6 +35,6 @@ private:
     Endpoint endpoint_;
 };
 
-static_assert(provider::Provider<OpenAIProvider>);
+static_assert(provider::Provider<OllamaProvider>);
 
-} // namespace agentty::provider::openai
+} // namespace agentty::provider::ollama

--- a/include/agentty/provider/ollama/transport.hpp
+++ b/include/agentty/provider/ollama/transport.hpp
@@ -1,0 +1,61 @@
+#pragma once
+// agentty::provider::ollama — dedicated transport for a local Ollama server.
+//
+// Ollama is NOT just an OpenAI-compatible endpoint. Its native /api/chat
+// protocol (the one Ollama itself documents and Zed's provider speaks) is a
+// better fit: it applies the model's own chat template, returns STRUCTURED
+// `message.tool_calls` (no leaked-JSON-in-content guessing), accepts
+// per-request `options.num_ctx` / `num_predict`, keeps the model resident via
+// `keep_alive`, and streams NDJSON (one JSON object per line) rather than SSE.
+//
+// This module is modelled on zed-industries/zed crates/ollama/src/ollama.rs:
+//   POST {base}/api/chat   {model, messages, stream, keep_alive, options, tools, think}
+//   NDJSON: {"message":{role,content,tool_calls,images,thinking}, "done":bool,
+//            "done_reason", "prompt_eval_count", "eval_count"}
+//
+// Unlike the OpenAI-compat path there is NO content-salvage: we trust the
+// structured tool_calls channel. Weak models that can't fill it simply chat
+// in plain text, which is the correct behaviour.
+//
+// The transport reuses openai::Endpoint / openai::Request (so provider
+// selection plumbing is unchanged — Ollama is still a Kind::OpenAI preset with
+// native_api=true) and dispatches the SAME agentty Msgs every other provider
+// does.
+
+#include <string>
+#include <vector>
+
+#include <nlohmann/json.hpp>
+
+#include "agentty/io/http.hpp"
+#include "agentty/provider/openai/transport.hpp"
+#include "agentty/runtime/msg.hpp"
+
+namespace agentty::provider::ollama {
+
+using openai::Endpoint;
+using openai::Request;
+using EventSink = std::function<void(Msg)>;
+
+// Run a streaming /api/chat request synchronously on the calling thread.
+// Each NDJSON frame is translated into an agentty Msg via `sink`. Returns when
+// the stream closes. `cancel` is polled at frame boundaries.
+void run_stream_sync(Request req, EventSink sink, http::CancelTokenPtr cancel = {});
+
+// System prompt tuned for local models served by Ollama. Plain, firm, with an
+// explicit "use earlier messages" recall reminder and an environment block;
+// includes the user's CLAUDE.md tiers but omits the verbose Claude agentic
+// prose and the big learned-memory / skills dumps that bloat the prompt and
+// confuse small models.
+[[nodiscard]] std::string system_prompt();
+
+// Build the native messages array from our Thread. Exposed for tests.
+[[nodiscard]] nlohmann::json build_messages(const std::vector<Message>& msgs);
+
+// Test-only: feed an NDJSON byte buffer through the live parser and collect
+// every dispatched Msg (no network round-trip).
+[[nodiscard]] std::vector<Msg> parse_ndjson_for_test(
+    std::string_view ndjson_bytes,
+    std::vector<std::string> known_tools = {});
+
+} // namespace agentty::provider::ollama

--- a/src/acp/server.cpp
+++ b/src/acp/server.cpp
@@ -25,6 +25,7 @@
 #include "agentty/io/persistence.hpp"
 #include "agentty/provider/anthropic/transport.hpp"
 #include "agentty/provider/openai/transport.hpp"
+#include "agentty/provider/ollama/transport.hpp"
 #include "agentty/provider/provider.hpp"
 #include "agentty/provider/selection.hpp"
 #include "agentty/runtime/msg.hpp"
@@ -679,14 +680,19 @@ StopReason AgentServer::stream_completion(Session& sess, bool& out_cancelled,
                                           bool suppress_tools) {
     provider::Request req;
     req.model         = sess.model.empty() ? model_id_ : sess.model;
-    // Weak models (small local / coder models, inferred from the model id)
-    // get a slim, decision-first prompt — the full Anthropic agentic prompt
-    // primes them to over-call tools even on a greeting. Strong models
-    // (Claude, large/tool-trained local models) keep the full prompt. The
-    // decision is per-model via ModelCapabilities, mirroring cmd_factory.
-    req.system_prompt = is_weak_model(req.model)
-        ? provider::openai::local_model_system_prompt()
-        : provider::anthropic::default_system_prompt();
+    // System prompt is chosen per provider (mirrors cmd_factory): Anthropic
+    // gets the full Claude agentic prompt, Ollama (native /api/chat) its own
+    // local-tuned prompt, other OpenAI-compatible backends the openai local
+    // prompt (verbose Claude prose breaks small models).
+    {
+        const auto& sel = provider::active();
+        if (sel.kind == provider::Kind::OpenAI && sel.openai_endpoint.native_api)
+            req.system_prompt = provider::ollama::system_prompt();
+        else if (sel.kind == provider::Kind::OpenAI)
+            req.system_prompt = provider::openai::local_model_system_prompt();
+        else
+            req.system_prompt = provider::anthropic::default_system_prompt();
+    }
     req.cancel        = sess.cancel;
     req.auth          = auth_;
     req.messages      = sess.thread.messages;

--- a/src/provider/ollama/transport.cpp
+++ b/src/provider/ollama/transport.cpp
@@ -1,0 +1,771 @@
+// agentty::provider::ollama — native /api/chat transport for a local Ollama
+// server. See transport.hpp for the rationale. Modelled on zed-industries/zed
+// crates/ollama/src/ollama.rs: NDJSON stream, structured message.tool_calls,
+// object-form tool arguments, keep_alive + options.num_predict.
+//
+// We prefer Ollama's structured tool_calls channel, but weak local models
+// (qwen2.5-coder, codellama, etc.) routinely leak tool calls as bare JSON in
+// `content` instead. So content is held-then-classified at the START of a
+// response: if it parses as a tool-call object/array (or ```json / <tool_call>
+// wrapper) naming an advertised tool, we salvage it into a structured call;
+// otherwise it flushes as ordinary prose. Once any structured tool_calls frame
+// arrives, salvage is disabled (the model can drive the real channel).
+
+#include "agentty/provider/ollama/transport.hpp"
+
+#include <algorithm>
+#include <chrono>
+#include <cstdlib>
+#include <filesystem>
+#include <fstream>
+#include <iterator>
+#include <optional>
+#include <string>
+#include <string_view>
+#include <vector>
+
+#include <nlohmann/json.hpp>
+
+#include "agentty/runtime/composer_attachment.hpp"
+#include "agentty/util/base64.hpp"
+
+namespace agentty::provider::ollama {
+
+using json = nlohmann::json;
+using auth::AuthHeader;
+using auth::ApiKeyHeader;
+using auth::BearerHeader;
+
+namespace {
+
+// ── UTF-8 scrub ─────────────────────────────────────────────────────────────
+// A tool output or pasted blob can carry invalid UTF-8; nlohmann's dump()
+// throws on it. Replace every malformed byte with U+FFFD.
+std::string scrub_utf8(std::string_view in) {
+    std::string out;
+    out.reserve(in.size());
+    const auto* p = reinterpret_cast<const unsigned char*>(in.data());
+    const auto* end = p + in.size();
+    auto push_replacement = [&] { out.append("\xEF\xBF\xBD"); };
+    while (p < end) {
+        unsigned char c = *p;
+        if (c < 0x80) { out.push_back(static_cast<char>(c)); ++p; continue; }
+        int extra = (c >= 0xF0) ? 3 : (c >= 0xE0) ? 2 : (c >= 0xC0) ? 1 : -1;
+        if (extra < 0 || p + extra >= end) { push_replacement(); ++p; continue; }
+        bool ok = true;
+        for (int k = 1; k <= extra; ++k)
+            if ((p[k] & 0xC0) != 0x80) { ok = false; break; }
+        if (!ok) { push_replacement(); ++p; continue; }
+        out.append(reinterpret_cast<const char*>(p), extra + 1);
+        p += extra + 1;
+    }
+    return out;
+}
+
+http::Headers build_request_headers(const AuthHeader& auth) {
+    http::Headers h;
+    h.push_back({"accept", "application/json"});
+    h.push_back({"content-type", "application/json"});
+    h.push_back({"user-agent", "agentty/" AGENTTY_VERSION});
+    // Ollama needs no auth by default, but a remote / proxied instance may
+    // sit behind a bearer key — emit it the same way the OpenAI family does.
+    std::visit([&](const auto& a) {
+        using T = std::decay_t<decltype(a)>;
+        if constexpr (std::is_same_v<T, ApiKeyHeader>) {
+            if (!a.value.empty())
+                h.push_back({"authorization", "Bearer " + a.value});
+        } else if constexpr (std::is_same_v<T, BearerHeader>) {
+            if (!a.token.empty())
+                h.push_back({"authorization", "Bearer " + a.token});
+        }
+    }, auth);
+    return h;
+}
+
+bool is_assistant_with_results(const Message& m) {
+    return m.role == Role::Assistant && !m.tool_calls.empty();
+}
+
+// ── Stream state ─────────────────────────────────────────────────────────────
+struct StreamCtx {
+    EventSink   sink;
+    std::string buf;          // NDJSON line buffer
+    std::size_t read_pos = 0;
+    int         tool_seq = 0; // uniquifies synthesised tool-call ids
+    StopReason  stop_reason = StopReason::Unspecified;
+    bool        terminated  = false;
+
+    // ── Leaked-tool-call salvage (weak local models) ────────────────────
+    // Content frames are held while the response COULD still be a bare
+    // tool-call JSON. Once we decide it's prose we flush + stop holding;
+    // once a structured tool_calls frame arrives salvage is disabled.
+    std::string text_hold;                 // buffered content under suspicion
+    bool        holding         = true;    // still buffering potential tool JSON
+    bool        salvage_eligible = true;   // can still be a tool call (start)
+    bool        any_text_flushed = false;
+    bool        any_structured_tool = false;
+    int         salvage_seq     = 0;       // uniquifies salvaged call ids
+    std::vector<std::string> known_tools;  // tool names we may salvage to
+    std::string full_content;              // every content byte (rescue scan)
+
+    StreamCtx() { buf.reserve(64 * 1024); }
+};
+
+constexpr std::size_t kCompactThreshold = 256 * 1024;
+
+// ── Salvage helpers (ported from openai/transport.cpp) ──────────────────
+
+// Could `s` be the START of a leaked tool-call? Only meaningful at the start
+// of a response (salvage_eligible). Detects: bare `{`, `[{`, `<tool_call>`,
+// or a ```json fence. Anything else is prose.
+[[nodiscard]] bool could_be_tool_json(std::string_view s) noexcept {
+    std::size_t i = 0;
+    while (i < s.size() && (s[i]==' '||s[i]=='\t'||s[i]=='\n'||s[i]=='\r')) ++i;
+    if (i >= s.size()) return true;            // only whitespace — undecided
+    std::string_view rest = s.substr(i);
+
+    if (rest.front() == '{') {
+        if (rest.size() == 1) return true;
+        std::string_view after = rest.substr(1);
+        std::size_t k = 0;
+        while (k < after.size() && (after[k]==' '||after[k]=='\t'
+               ||after[k]=='\n'||after[k]=='\r')) ++k;
+        if (k == after.size()) return true;
+        return after[k] == '"' || after[k] == '}';
+    }
+    if (rest.starts_with("[{") || rest.starts_with("[ {")) return true;
+    if (rest == "[" || rest == "[ ") return true;
+
+    if (rest.starts_with("<tool_call>")) return true;
+    constexpr std::string_view kTag = "<tool_call>";
+    if (rest.size() < kTag.size() && rest.front() == '<') {
+        for (std::size_t j = 0; j < rest.size(); ++j)
+            if (rest[j] != kTag[j]) return false;
+        return true;
+    }
+
+    if (rest.starts_with("```json")) return true;
+    if (rest.starts_with("```")) {
+        if (rest.size() <= 3) return true;
+        std::string_view after = rest.substr(3);
+        return after.empty() || after[0]=='\n' || after[0]=='\r'
+            || after[0]==' ' || after[0]=='\t' || after[0]=='j';
+    }
+    return false;
+}
+
+// Strip <tool_call>…</tool_call> and ```json…``` wrappers + surrounding ws.
+[[nodiscard]] std::string_view strip_tool_call_wrappers(std::string_view sv) noexcept {
+    auto ltrim = [](std::string_view& s) {
+        while (!s.empty() && (s.front()==' '||s.front()=='\t'
+                              ||s.front()=='\n'||s.front()=='\r')) s.remove_prefix(1);
+    };
+    auto rtrim = [](std::string_view& s) {
+        while (!s.empty() && (s.back()==' '||s.back()=='\t'
+                              ||s.back()=='\n'||s.back()=='\r')) s.remove_suffix(1);
+    };
+    ltrim(sv); rtrim(sv);
+    if (sv.starts_with("<tool_call>")) {
+        sv.remove_prefix(std::string_view{"<tool_call>"}.size());
+        if (auto p = sv.rfind("</tool_call>"); p != std::string_view::npos)
+            sv = sv.substr(0, p);
+        ltrim(sv); rtrim(sv);
+    }
+    if (sv.starts_with("```")) {
+        sv.remove_prefix(3);
+        // Skip an optional language tag on the fence line (json, sh, bash,
+        // tool_code, …) up to the first newline. Weak models wrap a leaked
+        // tool call in whatever fence they feel like.
+        if (auto nl = sv.find('\n'); nl != std::string_view::npos) {
+            std::string_view first = sv.substr(0, nl);
+            bool word = !first.empty();
+            for (char c : first)
+                if (!((c>='a'&&c<='z')||(c>='A'&&c<='Z')||c=='_'||c=='-')) { word=false; break; }
+            if (word) sv.remove_prefix(nl + 1);   // drop the lang tag line
+        } else if (sv.starts_with("json")) {
+            sv.remove_prefix(4);
+        }
+        ltrim(sv);
+        if (auto p = sv.rfind("```"); p != std::string_view::npos)
+            sv = sv.substr(0, p);
+        rtrim(sv);
+    }
+    return sv;
+}
+
+// Held buffer opens like a tool-call object but doesn't parse (wire cut off),
+// or is a wrapper-only remnant / empty `{}` — drop it rather than show garbage.
+[[nodiscard]] bool hold_is_truncated_tool_json(std::string_view sv) noexcept {
+    std::string_view raw = sv;
+    sv = strip_tool_call_wrappers(sv);
+    if (sv.empty() && raw != sv) return true;
+    if (sv == "json" || sv == "```" || sv == "`") return true;
+    if (sv == "{}") return true;
+    if (sv.empty() || sv.front() != '{') return false;
+    try { auto _ = json::parse(sv); (void)_; return false; }
+    catch (...) { return true; }
+}
+
+// Complete tool-call-shaped object naming an UNADVERTISED tool — drop it.
+[[nodiscard]] bool hold_is_unknown_tool_call(
+        std::string_view sv, const std::vector<std::string>& known) noexcept {
+    if (known.empty()) return false;
+    sv = strip_tool_call_wrappers(sv);
+    if (sv.empty() || sv.front() != '{') return false;
+    json j;
+    try { j = json::parse(sv); } catch (...) { return false; }
+    if (!j.is_object()) return false;
+    std::string name;
+    if (j.contains("name") && j["name"].is_string())
+        name = j["name"].get<std::string>();
+    else if (j.contains("function") && j["function"].is_string())
+        name = j["function"].get<std::string>();
+    else if (j.contains("tool") && j["tool"].is_string())
+        name = j["tool"].get<std::string>();
+    else
+        return false;
+    if (!j.contains("arguments") && !j.contains("parameters")) return false;
+    for (const auto& t : known) if (t == name) return false;
+    return true;
+}
+
+// Emit one salvaged tool call from a JSON object. Returns true if consumed
+// (emitted OR deliberately swallowed as a never-salvage footgun tool).
+[[nodiscard]] bool emit_salvaged_tool(StreamCtx& ctx, std::string_view sv) {
+    json j;
+    try { j = json::parse(sv); } catch (...) { return false; }
+    if (!j.is_object()) return false;
+    std::string name;
+    if (j.contains("name") && j["name"].is_string())
+        name = j["name"].get<std::string>();
+    else if (j.contains("function") && j["function"].is_string())
+        name = j["function"].get<std::string>();
+    else if (j.contains("tool") && j["tool"].is_string())
+        name = j["tool"].get<std::string>();
+    else
+        return false;
+    bool known = false;
+    for (const auto& t : ctx.known_tools) if (t == name) { known = true; break; }
+    if (!known) return false;
+    // Never auto-run footgun tools from a leaked guess: swallow the JSON.
+    static constexpr std::string_view kNeverSalvage[] = {
+        "remember", "forget", "wipe_memory", "skill"};
+    for (auto t : kNeverSalvage) if (t == name) return true;
+
+    std::string args = "{}";
+    if (j.contains("arguments")) {
+        const auto& a = j["arguments"];
+        if (a.is_string())      args = a.get<std::string>();
+        else if (!a.is_null())  args = a.dump();
+    } else if (j.contains("parameters")) {
+        const auto& p = j["parameters"];
+        if (p.is_string())      args = p.get<std::string>();
+        else if (!p.is_null())  args = p.dump();
+    }
+    std::string call_id = "call_salvaged_" + std::to_string(ctx.salvage_seq++);
+    ctx.sink(StreamToolUseStart{ToolCallId{call_id}, ToolName{name}});
+    ctx.sink(StreamToolUseDelta{args});
+    ctx.sink(StreamToolUseEnd{});
+    ctx.stop_reason = StopReason::ToolUse;
+    return true;
+}
+
+// Emit salvaged calls from a JSON array [{...},{...}]. Returns true if any.
+[[nodiscard]] bool emit_salvaged_tool_array(StreamCtx& ctx, std::string_view sv) {
+    json arr;
+    try { arr = json::parse(sv); } catch (...) { return false; }
+    if (!arr.is_array()) return false;
+    bool any = false;
+    for (const auto& item : arr)
+        if (item.is_object() && emit_salvaged_tool(ctx, item.dump())) any = true;
+    return any;
+}
+
+// Try to salvage the held content as a tool call (object or array, after
+// stripping wrappers). Returns true if a call was emitted/consumed.
+[[nodiscard]] bool try_salvage_hold(StreamCtx& ctx) {
+    std::string_view inner = strip_tool_call_wrappers(ctx.text_hold);
+    if (inner.empty()) return false;
+    if (inner.front() == '[') return emit_salvaged_tool_array(ctx, inner);
+    if (inner.front() == '{') return emit_salvaged_tool(ctx, inner);
+    return false;
+}
+
+// Flush held content as prose (dropping leaked/garbage tool JSON) and stop
+// holding. Called once we decide the hold is not a salvageable tool call.
+void flush_text_hold(StreamCtx& ctx) {
+    ctx.holding = false;
+    if (ctx.text_hold.empty()) return;
+    if (hold_is_truncated_tool_json(ctx.text_hold)) { ctx.text_hold.clear(); return; }
+    if (hold_is_unknown_tool_call(ctx.text_hold, ctx.known_tools)) {
+        ctx.text_hold.clear(); return;
+    }
+    ctx.sink(StreamTextDelta{ctx.text_hold});
+    ctx.any_text_flushed = true;
+    ctx.text_hold.clear();
+}
+
+// Last-resort: a weak model narrated prose AND buried a leaked tool call in a
+// fenced ```…``` block mid-response (so it was never held at the start). At
+// terminal close, if NOTHING was salvaged or structured, scan full_content for
+// the FIRST fenced block whose body is an advertised tool-call object and
+// salvage it. Conservative: only fires when no other call happened, only on
+// fenced blocks, only for advertised tools. Returns true if a call fired.
+bool rescue_tool_from_prose(StreamCtx& ctx) {
+    if (ctx.any_structured_tool) return false;
+    if (ctx.stop_reason == StopReason::ToolUse) return false;  // already salvaged
+    std::string_view sv{ctx.full_content};
+    std::size_t pos = 0;
+    while ((pos = sv.find("```", pos)) != std::string_view::npos) {
+        std::size_t open_end = sv.find('\n', pos + 3);
+        if (open_end == std::string_view::npos) break;
+        std::size_t close = sv.find("```", open_end + 1);
+        if (close == std::string_view::npos) break;
+        std::string_view body = sv.substr(open_end + 1, close - open_end - 1);
+        // trim
+        while (!body.empty() && (body.front()==' '||body.front()=='\t'
+               ||body.front()=='\n'||body.front()=='\r')) body.remove_prefix(1);
+        while (!body.empty() && (body.back()==' '||body.back()=='\t'
+               ||body.back()=='\n'||body.back()=='\r')) body.remove_suffix(1);
+        if (!body.empty() && (body.front()=='{' || body.front()=='[')) {
+            bool ok = body.front()=='['
+                ? emit_salvaged_tool_array(ctx, body)
+                : emit_salvaged_tool(ctx, body);
+            if (ok) return true;
+        }
+        pos = close + 3;
+    }
+    return false;
+}
+
+// Handle one native `message` object from an NDJSON frame.
+void handle_message(StreamCtx& ctx, const json& message) {
+    // Structured tool calls. Ollama returns them fully-formed in one frame
+    // (not streamed char-by-char), so emit Start+Delta+End back to back.
+    if (message.contains("tool_calls") && message["tool_calls"].is_array()
+        && !message["tool_calls"].empty()) {
+        int idx = 0;
+        for (const auto& tc : message["tool_calls"]) {
+            std::string name, args = "{}";
+            std::string call_id;
+            if (tc.contains("id") && tc["id"].is_string())
+                call_id = tc["id"].get<std::string>();
+            if (tc.contains("function") && tc["function"].is_object()) {
+                const auto& fn = tc["function"];
+                if (fn.contains("name") && fn["name"].is_string())
+                    name = fn["name"].get<std::string>();
+                if (fn.contains("arguments")) {
+                    const auto& a = fn["arguments"];
+                    if (a.is_string())     args = a.get<std::string>();
+                    else if (!a.is_null()) args = a.dump();
+                }
+            }
+            if (name.empty()) continue;
+            if (call_id.empty())
+                call_id = "call_ollama_" + std::to_string(ctx.tool_seq++)
+                        + "_" + std::to_string(idx);
+            ++idx;
+            ctx.sink(StreamToolUseStart{ToolCallId{call_id}, ToolName{name}});
+            ctx.sink(StreamToolUseDelta{args});
+            ctx.sink(StreamToolUseEnd{});
+            ctx.stop_reason = StopReason::ToolUse;
+            ctx.any_structured_tool = true;
+            ctx.salvage_eligible    = false;  // model drives the real channel
+        }
+        // A real structured call arrived — any held content is genuine prose
+        // that preceded it; flush it now.
+        if (ctx.holding) flush_text_hold(ctx);
+    }
+
+    // Assistant prose. Held-and-classified while salvage is still eligible so
+    // a leaked tool-call JSON can be recovered instead of dumped as text.
+    if (message.contains("content") && message["content"].is_string()) {
+        const auto& s = message["content"].get_ref<const std::string&>();
+        if (s.empty()) return;
+        ctx.full_content += s;
+        if (!ctx.holding) { ctx.sink(StreamTextDelta{s}); return; }
+        ctx.text_hold += s;
+        // Still could be a tool call? keep holding until `done` decides.
+        if (ctx.salvage_eligible && could_be_tool_json(ctx.text_hold)) return;
+        // Decided it's prose — release the buffer and stream the rest live.
+        flush_text_hold(ctx);
+    }
+}
+
+void dispatch_line(StreamCtx& ctx, std::string_view line) {
+    if (line.empty()) return;
+    json j;
+    try { j = json::parse(line); } catch (...) { return; }
+
+    if (j.contains("error")) {
+        std::string msg = j["error"].is_string()
+            ? j["error"].get<std::string>() : j["error"].dump();
+        ctx.sink(StreamError{msg, std::nullopt});
+        ctx.terminated = true;
+        return;
+    }
+    if (j.contains("message") && j["message"].is_object())
+        handle_message(ctx, j["message"]);
+
+    if (j.value("done", false)) {
+        // Final decision on any still-held content: try to salvage it as a
+        // leaked tool call, else flush as prose (dropping garbage JSON).
+        if (ctx.holding && !ctx.text_hold.empty()) {
+            if (!try_salvage_hold(ctx)) flush_text_hold(ctx);
+            else { ctx.text_hold.clear(); ctx.holding = false; }
+        } else if (ctx.holding) {
+            ctx.holding = false;
+        }
+        // Mid-prose buried tool call (narration + ```fenced``` JSON).
+        rescue_tool_from_prose(ctx);
+        StreamUsage su;
+        su.input_tokens  = j.value("prompt_eval_count", 0);
+        su.output_tokens = j.value("eval_count", 0);
+        if (su.input_tokens || su.output_tokens) ctx.sink(su);
+        auto reason = j.value("done_reason", std::string{"stop"});
+        if (ctx.stop_reason != StopReason::ToolUse)
+            ctx.stop_reason = (reason == "length") ? StopReason::MaxTokens
+                                                   : StopReason::EndTurn;
+    }
+}
+
+void feed_ndjson(StreamCtx& ctx, const char* data, std::size_t len) {
+    ctx.buf.append(data, len);
+    std::string_view buf{ctx.buf};
+    while (true) {
+        const auto nl = buf.find('\n', ctx.read_pos);
+        if (nl == std::string_view::npos) break;
+        std::string_view line = buf.substr(ctx.read_pos, nl - ctx.read_pos);
+        ctx.read_pos = nl + 1;
+        if (!line.empty() && line.back() == '\r') line.remove_suffix(1);
+        dispatch_line(ctx, line);
+    }
+    if (ctx.read_pos >= kCompactThreshold) {
+        ctx.buf.erase(0, ctx.read_pos);
+        ctx.read_pos = 0;
+    }
+}
+
+// ── CLAUDE.md memory tiers (user-authored, concise) ─────────────────────────
+std::filesystem::path home_dir() noexcept {
+    if (auto* h = std::getenv("HOME"); h && *h) return std::filesystem::path{h};
+#if defined(_WIN32)
+    if (auto* h = std::getenv("USERPROFILE"); h && *h)
+        return std::filesystem::path{h};
+#endif
+    return {};
+}
+
+std::string read_file(const std::filesystem::path& p) {
+    std::error_code ec;
+    if (p.empty() || !std::filesystem::exists(p, ec)) return {};
+    std::ifstream f(p, std::ios::binary);
+    if (!f) return {};
+    std::string s((std::istreambuf_iterator<char>(f)),
+                   std::istreambuf_iterator<char>());
+    if (s.size() > 64 * 1024) s.resize(64 * 1024);
+    return s;
+}
+
+std::string memory_blocks() {
+    std::string user    = read_file(home_dir() / "CLAUDE.md");
+    std::string project = read_file(std::filesystem::path{"CLAUDE.md"});
+    std::string local   = read_file(std::filesystem::path{"CLAUDE.local.md"});
+    if (user.empty() && project.empty() && local.empty()) return {};
+
+    std::string m = "\n\n<memory>\n"
+        "Project-specific guidance the user has authored. Treat these as "
+        "persistent context for THIS workspace and user.\n";
+    if (!user.empty())    m += "<user-memory>\n"    + user    + "\n</user-memory>\n";
+    if (!project.empty()) m += "<project-memory>\n" + project + "\n</project-memory>\n";
+    if (!local.empty())   m += "<local-memory>\n"   + local   + "\n</local-memory>\n";
+    m += "</memory>";
+    return m;
+}
+
+} // namespace
+
+// ── Messages array (native shape) ───────────────────────────────────────────
+// Ollama wants tool arguments as a JSON OBJECT (not a serialized string) and
+// tool results as role:"tool" with `tool_name`.
+json build_messages(const std::vector<Message>& msgs) {
+    json arr = json::array();
+    for (const auto& m : msgs) {
+        const bool has_text  = !m.text.empty();
+        const bool has_tools = is_assistant_with_results(m);
+        bool has_images = false;
+        if (m.role == Role::User)
+            for (const auto& img : m.images)
+                if (!img.bytes.empty()) { has_images = true; break; }
+
+        if (has_text || has_images || has_tools) {
+            json msg;
+            msg["role"] = (m.role == Role::User) ? "user" : "assistant";
+            std::string wire_text = m.attachments.empty()
+                ? m.text : attachment::expand(m.text, m.attachments);
+            msg["content"] = scrub_utf8(wire_text);
+            if (has_images) {
+                json imgs = json::array();
+                for (const auto& img : m.images)
+                    if (!img.bytes.empty())
+                        imgs.push_back(agentty::util::base64_encode(img.bytes));
+                if (!imgs.empty()) msg["images"] = std::move(imgs);
+            }
+            if (has_tools) {
+                json calls = json::array();
+                for (const auto& tc : m.tool_calls) {
+                    calls.push_back({
+                        {"id", tc.id.value},
+                        {"function", {
+                            {"name", tc.name.value},
+                            {"arguments", tc.args.is_null() ? json::object()
+                                                            : tc.args},
+                        }},
+                    });
+                }
+                msg["tool_calls"] = std::move(calls);
+            }
+            arr.push_back(std::move(msg));
+        }
+        if (has_tools) {
+            for (const auto& tc : m.tool_calls) {
+                std::string out = tc.output();
+                if (out.empty()) {
+                    if (tc.is_rejected())       out = "(rejected by user)";
+                    else if (!tc.is_terminal()) out = "(no output)";
+                }
+                arr.push_back({
+                    {"role", "tool"},
+                    {"tool_name", tc.name.value},
+                    {"content", scrub_utf8(out)},
+                });
+            }
+        }
+    }
+    return arr;
+}
+
+namespace {
+json build_tools(const std::vector<provider::ToolSpec>& tools) {
+    json arr = json::array();
+    for (const auto& t : tools) {
+        arr.push_back({
+            {"type", "function"},
+            {"function", {
+                {"name", t.name},
+                {"description", t.description},
+                {"parameters", t.input_schema},
+            }},
+        });
+    }
+    return arr;
+}
+} // namespace
+
+std::string system_prompt() {
+    std::string cwd;
+    try { cwd = std::filesystem::current_path().string(); } catch (...) {}
+
+#if defined(_WIN32)
+    const char* os_name = "Windows";
+    const char* shell   = "cmd.exe";
+#elif defined(__APPLE__)
+    const char* os_name = "macOS";
+    const char* shell   = "sh";
+#else
+    const char* os_name = "Linux";
+    const char* shell   = "sh";
+#endif
+
+    std::string out;
+    out += "You are agentty, a terminal coding assistant. You are helpful, "
+           "direct, and act on requests instead of asking which option to "
+           "pick. Keep replies concise.\n\n";
+
+    out += "CONVERSATION MEMORY\n"
+           "- The full conversation so far is in the messages above. ALWAYS "
+           "use earlier messages to answer follow-up questions (names, files, "
+           "decisions the user already gave you).\n"
+           "- If the user told you a fact earlier (e.g. their name), recall it "
+           "from the conversation; never say you don't have it.\n\n";
+
+    out += "TOOLS\n"
+           "- Tools let you read/edit files and run commands. Call a tool ONLY "
+           "when the task needs it. For greetings, chit-chat, or questions you "
+           "can answer from the conversation, reply in plain text \xE2\x80\x94 "
+           "do NOT call a tool.\n"
+           "- When a task DOES need an action (rename/move/delete a file, run a "
+           "shell command, read or edit code), you MUST actually call the tool. "
+           "NEVER describe the command in prose or a code block and claim it "
+           "ran \xE2\x80\x94 that does nothing. NEVER say a file was created, "
+           "renamed, or deleted unless a tool you called returned that result.\n"
+           "- To run a shell command (mv, rm, mkdir, git, etc.) call the `bash` "
+           "tool with a `command` argument. There is NO `git` or `mv` tool \xE2\x80\x94 "
+           "use `bash`. To edit an existing file use `edit`; use `write` only to "
+           "create a new file.\n"
+           "- Emit tool calls through the tool-call channel, NOT as JSON or a "
+           "```code block``` in your reply.\n"
+           "- Make ONE tool call at a time and wait for its result. Never "
+           "invent a tool result.\n"
+           "- Never call remember/forget/wipe_memory unless the user asks you "
+           "to remember or forget something.\n\n";
+
+    out += "OUTPUT\n"
+           "- Output is rendered as GitHub-flavoured markdown in a terminal. "
+           "Use fenced code blocks for code. Keep tables small.\n\n";
+
+    out += "ENVIRONMENT\n";
+    out += "- os: ";    out += os_name; out += "\n";
+    out += "- shell: "; out += shell;   out += "\n";
+    if (!cwd.empty()) { out += "- cwd: "; out += cwd; out += "\n"; }
+
+    out += memory_blocks();
+    return out;
+}
+
+// ── Streaming entry point ────────────────────────────────────────────────────
+void run_stream_sync(Request req, EventSink sink, http::CancelTokenPtr cancel) {
+    StreamCtx ctx;
+    ctx.sink = std::move(sink);
+    // Salvage may only synthesise calls to tools we actually advertised.
+    ctx.known_tools.reserve(req.tools.size());
+    for (const auto& t : req.tools) ctx.known_tools.push_back(t.name);
+    // No tools advertised → nothing to salvage to; treat all content as prose.
+    if (req.tools.empty()) { ctx.holding = false; ctx.salvage_eligible = false; }
+
+    auto emit_terminal = [](StreamCtx& c, std::optional<std::string> err,
+                            std::optional<std::chrono::seconds> retry_after = {}) {
+        if (c.terminated) return;
+        // Stream ended without a `done` frame (e.g. wire cut) but content may
+        // still be held — salvage or flush it before the terminal event.
+        if (!err && c.holding && !c.text_hold.empty()) {
+            if (!try_salvage_hold(c)) flush_text_hold(c);
+            else { c.text_hold.clear(); c.holding = false; }
+        }
+        if (!err) rescue_tool_from_prose(c);
+        if (err) c.sink(StreamError{*err, retry_after});
+        else     c.sink(StreamFinished{c.stop_reason});
+        c.terminated = true;
+    };
+
+    // ── Build /api/chat body ─────────────────────────────────────────────────
+    json body;
+    body["model"]  = req.model;
+    body["stream"] = true;
+    // Keep the model resident between turns so the next prompt is instant.
+    body["keep_alive"] = "10m";
+    // num_predict = max output tokens (Ollama default is a low ~128, which
+    // truncates real answers). num_ctx is left to the model's Modelfile /
+    // server default so we don't shrink a model's window by guessing.
+    body["options"] = {{"num_predict", req.max_tokens}};
+
+    json messages = json::array();
+    if (!req.system_prompt.empty())
+        messages.push_back({{"role", "system"},
+                            {"content", scrub_utf8(req.system_prompt)}});
+    for (auto& m : build_messages(req.messages))
+        messages.push_back(std::move(m));
+    body["messages"] = std::move(messages);
+
+    if (!req.tools.empty()) body["tools"] = build_tools(req.tools);
+
+    std::string body_str;
+    try {
+        body_str = body.dump();
+    } catch (const nlohmann::json::exception& e) {
+        ctx.sink(StreamError{std::string{"request build failed (invalid UTF-8): "}
+                             + e.what()});
+        ctx.sink(StreamFinished{StopReason::Unspecified});
+        return;
+    }
+
+    // ── HTTP request ─────────────────────────────────────────────────────────
+    http::Request hreq;
+    hreq.method    = http::HttpMethod::Post;
+    hreq.host      = req.endpoint.host;
+    hreq.port      = req.endpoint.port;
+    hreq.path      = "/api/chat";
+    hreq.plaintext = !req.endpoint.use_tls;
+    if (const auto& ov = http::agentty_api_host_override(); ov.active()) {
+        hreq.dial_host = ov.host;
+        hreq.dial_port = ov.port;
+    }
+    hreq.headers = build_request_headers(req.auth);
+    hreq.body    = std::move(body_str);
+
+    int  http_status = 0;
+    bool is_success  = false;
+    std::string error_body;
+
+    http::StreamHandler handler;
+    handler.on_headers = [&](int status, const http::Headers&) {
+        http_status = status;
+        is_success  = (status >= 200 && status < 300);
+    };
+    handler.on_chunk = [&](std::string_view chunk) -> bool {
+        if (is_success) {
+            feed_ndjson(ctx, chunk.data(), chunk.size());
+        } else if (error_body.size() < 64 * 1024) {
+            error_body.append(chunk.data(),
+                std::min(chunk.size(), 64 * 1024 - error_body.size()));
+        }
+        return true;
+    };
+
+    http::Timeouts tos;
+    tos.connect = std::chrono::milliseconds(10'000);
+    tos.total   = std::chrono::milliseconds(0);   // streaming unbounded
+    tos.ping    = std::chrono::milliseconds(15'000);
+    tos.idle    = std::chrono::milliseconds(120'000);  // local gen can be slow
+
+    auto result = http::default_client().stream(hreq, std::move(handler),
+                                                tos, std::move(cancel));
+
+    if (!result) {
+        std::string msg = std::string{"http: "} + result.error().render();
+        msg += "  (is Ollama running? start it with 'ollama serve', or check "
+               "--provider host:port)";
+        emit_terminal(ctx, std::move(msg));
+        return;
+    }
+
+    if (!is_success) {
+        std::string msg = "HTTP " + std::to_string(http_status);
+        try {
+            auto j = json::parse(error_body);
+            if (j.contains("error") && j["error"].is_string())
+                msg += ": " + j["error"].get<std::string>();
+            else if (!error_body.empty())
+                msg += ": " + error_body.substr(0, 300);
+        } catch (...) {
+            if (!error_body.empty()) msg += ": " + error_body.substr(0, 300);
+        }
+        if (http_status == 404)
+            msg += "  (model not loaded — run 'ollama pull " + req.model + "')";
+        emit_terminal(ctx, std::move(msg));
+        return;
+    }
+
+    // 2xx — guarantee a terminal event even if `done` never arrived.
+    emit_terminal(ctx, std::nullopt);
+}
+
+std::vector<Msg> parse_ndjson_for_test(std::string_view ndjson_bytes,
+                                       std::vector<std::string> known_tools) {
+    std::vector<Msg> out;
+    StreamCtx ctx;
+    ctx.sink = [&out](Msg m) { out.push_back(std::move(m)); };
+    ctx.known_tools = std::move(known_tools);
+    if (ctx.known_tools.empty()) { ctx.holding = false; ctx.salvage_eligible = false; }
+    feed_ndjson(ctx, ndjson_bytes.data(), ndjson_bytes.size());
+    // Mirror run_stream_sync's terminal flush so tests see the live sequence.
+    if (ctx.holding && !ctx.text_hold.empty()) {
+        if (!try_salvage_hold(ctx)) flush_text_hold(ctx);
+        else { ctx.text_hold.clear(); ctx.holding = false; }
+    }
+    rescue_tool_from_prose(ctx);
+    if (!ctx.terminated) ctx.sink(StreamFinished{ctx.stop_reason});
+    return out;
+}
+
+} // namespace agentty::provider::ollama

--- a/src/provider/openai/transport.cpp
+++ b/src/provider/openai/transport.cpp
@@ -26,6 +26,7 @@
 #include <chrono>
 #include <cstring>
 #include <filesystem>
+#include <fstream>
 #include <optional>
 #include <string>
 #include <string_view>
@@ -34,7 +35,6 @@
 #include <nlohmann/json.hpp>
 
 #include "agentty/runtime/composer_attachment.hpp"
-#include "agentty/tool/skills.hpp"
 #include "agentty/util/base64.hpp"
 
 namespace agentty::provider::openai {
@@ -275,6 +275,9 @@ void close_active_tool(StreamCtx& ctx) {
     // Likewise a fence-word-only remnant the stripper left (e.g. the model
     // emitted exactly "json" or "```json" with nothing parseable).
     if (sv == "json" || sv == "```" || sv == "`") return true;
+    // Empty object "{}" — qwen2.5-coder:14b outputs this when tools are
+    // passed but it doesn't want to call any. It's garbage, not prose.
+    if (sv == "{}") return true;
     if (sv.empty() || sv.front() != '{') return false;
     try { auto _ = json::parse(sv); (void)_; return false; }   // complete — keep as text
     catch (...) { return true; }                    // truncated — drop
@@ -1312,8 +1315,9 @@ void run_stream_sync(Request req, EventSink sink, http::CancelTokenPtr cancel) {
 
     if (native) {
         // Ollama native /api/chat: system prompt as a role:"system" message,
-        // structured tool_calls, NDJSON response. No max_tokens/stream_options
-        // (Ollama uses `options.num_predict`); default generation is fine.
+        // structured tool_calls, NDJSON response.
+        // num_predict = max output tokens (Ollama default is low ~128).
+        body["options"] = {{"num_predict", req.max_tokens}};
         json messages = json::array();
         if (!req.system_prompt.empty())
             messages.push_back({{"role", "system"},
@@ -1466,6 +1470,53 @@ void run_stream_sync(Request req, EventSink sink, http::CancelTokenPtr cancel) {
     emit_terminal(ctx, std::nullopt);
 }
 
+namespace {
+
+[[nodiscard]] std::filesystem::path lm_home_dir() noexcept {
+    if (auto* h = std::getenv("HOME"); h && *h) return std::filesystem::path{h};
+#if defined(_WIN32)
+    if (auto* h = std::getenv("USERPROFILE"); h && *h)
+        return std::filesystem::path{h};
+#endif
+    return {};
+}
+
+[[nodiscard]] std::string lm_read_file(const std::filesystem::path& p) {
+    std::error_code ec;
+    if (p.empty() || !std::filesystem::exists(p, ec)) return {};
+    std::ifstream f(p, std::ios::binary);
+    if (!f) return {};
+    std::string s((std::istreambuf_iterator<char>(f)),
+                   std::istreambuf_iterator<char>());
+    if (s.size() > 64 * 1024) s.resize(64 * 1024);
+    return s;
+}
+
+// CLAUDE.md tiers only. The Anthropic prompt also injects agent-authored
+// learned-memory (load_recent_*) and the skills catalog, but those can run to
+// thousands of tokens and demonstrably confuse small local models on simple
+// prompts (a 14b answered "hi" with "I didn't understand" once the learned
+// facts were present). Local models get the concise user-authored CLAUDE.md
+// guidance and nothing else.
+[[nodiscard]] std::string local_memory_blocks() {
+    std::string user    = lm_read_file(lm_home_dir() / "CLAUDE.md");
+    std::string project = lm_read_file(std::filesystem::path{"CLAUDE.md"});
+    std::string local   = lm_read_file(std::filesystem::path{"CLAUDE.local.md"});
+
+    if (user.empty() && project.empty() && local.empty()) return {};
+
+    std::string m = "\n\n<memory>\n"
+        "Project-specific guidance the user has authored. Treat these as "
+        "persistent context for THIS workspace and user.\n";
+    if (!user.empty())    m += "<user-memory>\n"    + user    + "\n</user-memory>\n";
+    if (!project.empty()) m += "<project-memory>\n" + project + "\n</project-memory>\n";
+    if (!local.empty())   m += "<local-memory>\n"   + local   + "\n</local-memory>\n";
+    m += "</memory>";
+    return m;
+}
+
+} // namespace
+
 std::string_view local_model_prompt_addendum() {
     return
         "\n\nMost messages are answered in plain words — greetings, small "
@@ -1476,41 +1527,62 @@ std::string_view local_model_prompt_addendum() {
 }
 
 std::string local_model_system_prompt() {
-#if defined(_WIN32)
-    constexpr const char* os_name = "Windows";
-    constexpr const char* shell   = "cmd.exe";
-#elif defined(__APPLE__)
-    constexpr const char* os_name = "macOS";
-    constexpr const char* shell   = "sh";
-#else
-    constexpr const char* os_name = "Linux";
-    constexpr const char* shell   = "sh";
-#endif
     std::string cwd;
     try { cwd = std::filesystem::current_path().string(); } catch (...) {}
 
+#if defined(_WIN32)
+    const char* os_name = "Windows";
+    const char* shell   = "cmd.exe";
+#elif defined(__APPLE__)
+    const char* os_name = "macOS";
+    const char* shell   = "sh";
+#else
+    const char* os_name = "Linux";
+    const char* shell   = "sh";
+#endif
+
+    // Tuned for OpenAI-compatible / local models (Ollama, llama.cpp, vLLM).
+    // Plainer and firmer than the Claude prompt: local models follow short
+    // imperative rules better than long prose, and they read recent history
+    // less reliably so the recall reminder is explicit.
     std::string out;
-    out.reserve(2048);
-    out += "You are agentty, a concise, friendly terminal assistant. Answer "
-           "directly and naturally.\n";
-    out += local_model_prompt_addendum();
-    out += "\n\n<tools>\n"
-           "When you DO need a tool: read/write/edit operate on files; bash "
-           "runs a shell command; grep/glob/list_dir search the project. "
-           "Use exact paths. Make ONE call, wait for its result, then "
-           "continue or answer.\n"
-           "</tools>\n";
-    out += "\n<environment>\n  os: ";
-    out += os_name;
-    out += "\n  shell: ";
-    out += shell;
-    out += "\n";
-    if (!cwd.empty()) { out += "  cwd: "; out += cwd; out += "\n"; }
-    out += "</environment>\n";
-    // No skills catalog here on purpose. Weak local models hallucinate a
-    // `skill` tool call from the catalog listing (even on a greeting), which
-    // then fails / loops. On-demand skills stay available via the explicit
-    // /skill-name slash command; they're just not advertised to the model.
+    out += "You are agentty, a terminal coding assistant. You are helpful, "
+           "direct, and act on requests instead of asking which option to "
+           "pick. Keep replies concise.\n\n";
+
+    out += "CONVERSATION MEMORY\n"
+           "- The full conversation so far is provided in the messages. "
+           "ALWAYS use earlier messages to answer follow-up questions "
+           "(names, files, decisions the user already gave you).\n"
+           "- If the user told you a fact earlier (e.g. their name), recall "
+           "it from the conversation; do not say you don't have it.\n\n";
+
+    out += "TOOLS\n"
+           "- Tools let you read/edit files and run commands. Call a tool "
+           "ONLY when the task needs it (touch files, run a command, search "
+           "the codebase). For greetings, chit-chat, or questions you can "
+           "answer from the conversation, reply in plain text \u2014 do NOT call "
+           "a tool.\n"
+           "- To edit an existing file use `edit` (targeted change). Use "
+           "`write` only to create a new file.\n"
+           "- Make ONE tool call at a time and wait for its result before "
+           "the next. Never invent a tool result.\n"
+           "- Never call remember/forget/wipe_memory unless the user asks "
+           "you to remember or forget something.\n\n";
+
+    out += "OUTPUT\n"
+           "- Output is rendered as GitHub-flavoured markdown in a terminal. "
+           "Use fenced code blocks for code. Keep tables small.\n\n";
+
+    out += "ENVIRONMENT\n";
+    out += "- os: "; out += os_name; out += "\n";
+    out += "- shell: "; out += shell; out += "\n";
+    if (!cwd.empty()) { out += "- cwd: "; out += cwd; out += "\n"; }
+
+    // User/project CLAUDE.md tiers only. Skills catalog + learned-memory are
+    // omitted for local models (token bloat + confusion on small models);
+    // skills still activate explicitly via /skill-name.
+    out += local_memory_blocks();
     return out;
 }
 

--- a/src/runtime/app/cmd_factory.cpp
+++ b/src/runtime/app/cmd_factory.cpp
@@ -14,6 +14,7 @@
 #include "agentty/io/http.hpp"
 #include "agentty/provider/anthropic/transport.hpp"
 #include "agentty/provider/openai/transport.hpp"
+#include "agentty/provider/ollama/transport.hpp"
 #include "agentty/provider/selection.hpp"
 #include "agentty/tool/registry.hpp"
 #include "agentty/tool/spec.hpp"
@@ -487,19 +488,22 @@ Cmd<Msg> launch_stream(Model& m) {
         // Build wire payload off the UI thread.
         provider::Request req;
         req.model         = std::move(model_id);
-        // Weak models (small local / coder models inferred from the model id)
-        // choke on the full Claude agentic prompt — the verbose "Act, don't
-        // ask" + memory-tools sections prime them to over-call tools and leak
-        // them as content text, even on a bare "hi". Send a slim decision-
-        // first prompt instead. Strong models (Claude, large/tool-trained
-        // local models) get the full prompt. The decision is per-model via
-        // ModelCapabilities, not per-provider — a 70B llama on Ollama is
-        // treated as strong, a 7B coder on any endpoint as weak.
-        const bool weak_model = is_weak_model(req.model);
-        if (weak_model)
+        // System prompt is chosen PER PROVIDER. Anthropic (Claude) gets the
+        // full Claude agentic prompt. Ollama (native /api/chat) gets its own
+        // local-tuned prompt. Other OpenAI-compatible backends get the
+        // openai local-model prompt. The verbose Claude prose primes small
+        // local models to over-call tools and some break outright on it.
+        const auto& sel_now = provider::active();
+        const bool openai_provider = sel_now.kind == provider::Kind::OpenAI;
+        if (openai_provider && sel_now.openai_endpoint.native_api)
+            req.system_prompt = provider::ollama::system_prompt();
+        else if (openai_provider)
             req.system_prompt = provider::openai::local_model_system_prompt();
         else
             req.system_prompt = provider::anthropic::default_system_prompt();
+        // Weak models (small local / coder ids) still hide a few footgun
+        // tools below; the prompt no longer branches on it.
+        const bool weak_model = is_weak_model(req.model);
         req.cancel        = cancel;
         req.auth          = std::move(auth);
         req.retry_count   = retry_count;

--- a/src/runtime/main.cpp
+++ b/src/runtime/main.cpp
@@ -49,6 +49,7 @@
 #include "agentty/io/persistence.hpp"
 #include "agentty/provider/anthropic/provider.hpp"
 #include "agentty/provider/openai/provider.hpp"
+#include "agentty/provider/ollama/provider.hpp"
 #include "agentty/provider/selection.hpp"
 #include "agentty/tool/skills.hpp"
 #include "agentty/tool/util/fs_helpers.hpp"
@@ -354,8 +355,17 @@ int main(int argc, char** argv) {
         (provider::Request req, provider::EventSink sink) {
             const auto& sel = provider::active();
             if (sel.kind == provider::Kind::OpenAI) {
-                provider::openai::OpenAIProvider p{sel.openai_endpoint};
-                p.stream(std::move(req), std::move(sink));
+                // Ollama speaks its own native /api/chat dialect — route it to
+                // the dedicated provider (structured tool_calls, keep_alive,
+                // num_predict). Every other OpenAI-family backend uses the
+                // compat /v1/chat/completions transport.
+                if (sel.openai_endpoint.native_api) {
+                    provider::ollama::OllamaProvider p{sel.openai_endpoint};
+                    p.stream(std::move(req), std::move(sink));
+                } else {
+                    provider::openai::OpenAIProvider p{sel.openai_endpoint};
+                    p.stream(std::move(req), std::move(sink));
+                }
             } else {
                 anthropic_provider.stream(std::move(req), std::move(sink));
             }

--- a/tests/model_caps_test.cpp
+++ b/tests/model_caps_test.cpp
@@ -48,12 +48,18 @@ static void test_small_local_coder_weak() {
 }
 
 static void test_large_models_strong() {
-    // >= ~14B follows tool schemas regardless of family.
-    CHECK(!weak("qwen2.5-coder:32b"));        // weak family but large
+    // Large models with NO weak-family signal follow tool schemas reliably.
     CHECK(!weak("llama3.1:70b"));
-    CHECK(!weak("codellama:34b"));
-    CHECK(!weak("mixtral:8x22b"));            // 22b matched
-    CHECK(!weak("deepseek-coder:33b"));
+    CHECK(!weak("mixtral:8x22b"));            // 22b matched, no weak family
+}
+
+static void test_weak_family_wins_over_size() {
+    // Known weak / coder-only families leak tool JSON at ANY size — the
+    // weak-family signal beats the raw >= 14B size shortcut.
+    CHECK(weak("qwen2.5-coder:14b"));         // the live case
+    CHECK(weak("qwen2.5-coder:32b"));
+    CHECK(weak("codellama:34b"));
+    CHECK(weak("deepseek-coder:33b"));
 }
 
 static void test_tool_trained_families_strong() {
@@ -105,6 +111,7 @@ int main() {
     test_claude_never_weak();
     test_small_local_coder_weak();
     test_large_models_strong();
+    test_weak_family_wins_over_size();
     test_tool_trained_families_strong();
     test_tiny_strong_family_still_weak();
     test_unknown_id_defaults_strong();

--- a/tests/ollama_transport_test.cpp
+++ b/tests/ollama_transport_test.cpp
@@ -1,0 +1,288 @@
+// ollama_transport_test — verifies the dedicated Ollama /api/chat transport's
+// pure translation layer with NO network:
+//
+//   1. build_messages    — Thread messages → native messages array
+//                          (assistant tool_calls with OBJECT args + id,
+//                          separate role:"tool" results with tool_name,
+//                          user images as base64 array).
+//   2. parse_ndjson_for_test — scripted NDJSON frames → the agentty Msg
+//                          sequence the reducer consumes (text deltas,
+//                          STRUCTURED tool_calls → Start/Delta/End, usage,
+//                          done_reason→StopReason). NO content-salvage:
+//                          a bare JSON object in content stays prose.
+//   3. system_prompt     — contains the recall reminder + env block.
+//
+// Run: build the `ollama_transport_test` target, execute. Exit 0 = pass.
+
+#include <cstdio>
+#include <string>
+#include <string_view>
+#include <variant>
+#include <vector>
+
+#include "agentty/provider/ollama/transport.hpp"
+
+using namespace agentty;
+namespace oll = agentty::provider::ollama;
+
+static int g_failures = 0;
+#define CHECK(cond)                                                            \
+    do {                                                                       \
+        if (!(cond)) {                                                         \
+            std::fprintf(stderr, "FAIL %s:%d  %s\n", __FILE__, __LINE__, #cond); \
+            ++g_failures;                                                      \
+        }                                                                      \
+    } while (0)
+
+template <class Leaf>
+const Leaf* get_leaf(const Msg& m) {
+    const Leaf* found = nullptr;
+    std::visit([&](const auto& domain) {
+        std::visit([&](const auto& leaf) {
+            if constexpr (std::is_same_v<std::decay_t<decltype(leaf)>, Leaf>)
+                found = &leaf;
+        }, domain);
+    }, m);
+    return found;
+}
+
+template <class Leaf>
+int count_leaf(const std::vector<Msg>& msgs) {
+    int n = 0;
+    for (const auto& m : msgs) if (get_leaf<Leaf>(m)) ++n;
+    return n;
+}
+
+static std::string joined_text(const std::vector<Msg>& msgs) {
+    std::string s;
+    for (const auto& m : msgs)
+        if (const auto* d = get_leaf<StreamTextDelta>(m)) s += d->text;
+    return s;
+}
+
+// ── 1. build_messages ────────────────────────────────────────────────────────
+static void test_build_messages_text() {
+    std::vector<Message> msgs;
+    Message u; u.role = Role::User; u.text = "hello"; msgs.push_back(u);
+    Message a; a.role = Role::Assistant; a.text = "hi there"; msgs.push_back(a);
+
+    auto arr = oll::build_messages(msgs);
+    CHECK(arr.is_array());
+    CHECK(arr.size() == 2);
+    CHECK(arr[0]["role"] == "user");
+    CHECK(arr[0]["content"] == "hello");
+    CHECK(arr[1]["role"] == "assistant");
+    CHECK(arr[1]["content"] == "hi there");
+}
+
+static void test_build_messages_tool_calls() {
+    // Assistant message with a terminal tool call → assistant msg carries
+    // tool_calls[{id, function:{name, arguments:OBJECT}}] AND a separate
+    // role:"tool" message with tool_name + content follows it.
+    std::vector<Message> msgs;
+    Message a;
+    a.role = Role::Assistant;
+    a.text = "";
+    ToolUse tc;
+    tc.id   = ToolCallId{"call_1"};
+    tc.name = ToolName{"read"};
+    tc.args = nlohmann::json{{"path", "/etc/hostname"}};
+    tc.status = ToolUse::Done{{}, {}, "myhost"};
+    a.tool_calls.push_back(std::move(tc));
+    msgs.push_back(std::move(a));
+
+    auto arr = oll::build_messages(msgs);
+    CHECK(arr.size() == 2);
+    // assistant message
+    CHECK(arr[0]["role"] == "assistant");
+    CHECK(arr[0].contains("tool_calls"));
+    CHECK(arr[0]["tool_calls"].size() == 1);
+    CHECK(arr[0]["tool_calls"][0]["id"] == "call_1");
+    CHECK(arr[0]["tool_calls"][0]["function"]["name"] == "read");
+    // arguments must be a JSON OBJECT, not a serialized string
+    CHECK(arr[0]["tool_calls"][0]["function"]["arguments"].is_object());
+    CHECK(arr[0]["tool_calls"][0]["function"]["arguments"]["path"]
+          == "/etc/hostname");
+    // tool result message
+    CHECK(arr[1]["role"] == "tool");
+    CHECK(arr[1]["tool_name"] == "read");
+    CHECK(arr[1]["content"] == "myhost");
+}
+
+static void test_build_messages_images() {
+    std::vector<Message> msgs;
+    Message u; u.role = Role::User; u.text = "what is this?";
+    ImageContent img; img.media_type = "image/png"; img.bytes = "abc";
+    u.images.push_back(std::move(img));
+    msgs.push_back(std::move(u));
+
+    auto arr = oll::build_messages(msgs);
+    CHECK(arr.size() == 1);
+    CHECK(arr[0].contains("images"));
+    CHECK(arr[0]["images"].is_array());
+    CHECK(arr[0]["images"].size() == 1);
+    CHECK(arr[0]["images"][0].is_string());
+}
+
+// ── 2. parse_ndjson ──────────────────────────────────────────────────────────
+static void test_ndjson_plain_text() {
+    std::string nd =
+        "{\"message\":{\"role\":\"assistant\",\"content\":\"Hello \"}}\n"
+        "{\"message\":{\"role\":\"assistant\",\"content\":\"Ayush\"}}\n"
+        "{\"message\":{\"role\":\"assistant\",\"content\":\"\"},"
+        "\"done\":true,\"done_reason\":\"stop\","
+        "\"prompt_eval_count\":10,\"eval_count\":3}\n";
+    auto msgs = oll::parse_ndjson_for_test(nd);
+    CHECK(joined_text(msgs) == "Hello Ayush");
+    CHECK(count_leaf<StreamFinished>(msgs) == 1);
+    CHECK(count_leaf<StreamUsage>(msgs) == 1);
+    // No tool calls leaked.
+    CHECK(count_leaf<StreamToolUseStart>(msgs) == 0);
+}
+
+static void test_ndjson_structured_tool_call() {
+    std::string nd =
+        "{\"message\":{\"role\":\"assistant\",\"content\":\"\","
+        "\"tool_calls\":[{\"id\":\"call_x\",\"function\":{\"name\":\"read\","
+        "\"arguments\":{\"path\":\"/tmp/f\"}}}]},"
+        "\"done_reason\":\"stop\",\"done\":true}\n";
+    auto msgs = oll::parse_ndjson_for_test(nd);
+    CHECK(count_leaf<StreamToolUseStart>(msgs) == 1);
+    CHECK(count_leaf<StreamToolUseEnd>(msgs) == 1);
+    // The arguments object is forwarded as the delta payload.
+    bool saw_args = false;
+    for (const auto& m : msgs)
+        if (const auto* d = get_leaf<StreamToolUseDelta>(m))
+            if (d->partial_json.find("/tmp/f") != std::string::npos) saw_args = true;
+    CHECK(saw_args);
+    // StopReason should be ToolUse.
+    bool tool_stop = false;
+    for (const auto& m : msgs)
+        if (const auto* f = get_leaf<StreamFinished>(m))
+            if (f->stop_reason == StopReason::ToolUse) tool_stop = true;
+    CHECK(tool_stop);
+}
+
+static void test_ndjson_content_salvage_to_tool() {
+    // A weak model leaks a tool call as bare JSON in CONTENT. With the tool
+    // advertised, it is salvaged into a STRUCTURED call (not shown as text).
+    std::string nd =
+        "{\"message\":{\"role\":\"assistant\",\"content\":"
+        "\"{\\\"name\\\":\\\"write\\\",\\\"arguments\\\":"
+        "{\\\"file_path\\\":\\\"/tmp/f\\\"}}\"}}\n"
+        "{\"message\":{\"role\":\"assistant\",\"content\":\"\"},"
+        "\"done\":true,\"done_reason\":\"stop\"}\n";
+    auto msgs = oll::parse_ndjson_for_test(nd, {"write", "read"});
+    CHECK(count_leaf<StreamToolUseStart>(msgs) == 1);
+    CHECK(count_leaf<StreamToolUseEnd>(msgs) == 1);
+    bool saw_args = false;
+    for (const auto& m : msgs)
+        if (const auto* d = get_leaf<StreamToolUseDelta>(m))
+            if (d->partial_json.find("/tmp/f") != std::string::npos) saw_args = true;
+    CHECK(saw_args);
+    // Salvaged JSON must NOT also appear as visible prose.
+    CHECK(joined_text(msgs).find("\"name\"") == std::string::npos);
+}
+
+static void test_ndjson_no_tools_means_no_salvage() {
+    // With NO tools advertised, JSON-looking content is plain text — there's
+    // nothing to salvage to, so don't swallow legitimate prose.
+    std::string nd =
+        "{\"message\":{\"role\":\"assistant\",\"content\":"
+        "\"{\\\"name\\\":\\\"read\\\",\\\"arguments\\\":{}}\"}}\n"
+        "{\"message\":{\"role\":\"assistant\",\"content\":\"\"},"
+        "\"done\":true,\"done_reason\":\"stop\"}\n";
+    auto msgs = oll::parse_ndjson_for_test(nd);   // no known_tools
+    CHECK(count_leaf<StreamToolUseStart>(msgs) == 0);
+    CHECK(joined_text(msgs).find("\"name\"") != std::string::npos);
+}
+
+static void test_ndjson_footgun_tool_swallowed() {
+    // A leaked `remember` call (footgun tool) is NEVER auto-run AND never
+    // surfaced as garbage text — it is silently swallowed.
+    std::string nd =
+        "{\"message\":{\"role\":\"assistant\",\"content\":"
+        "\"{\\\"name\\\":\\\"remember\\\",\\\"arguments\\\":"
+        "{\\\"text\\\":\\\"hi\\\"}}\"}}\n"
+        "{\"message\":{\"role\":\"assistant\",\"content\":\"\"},"
+        "\"done\":true,\"done_reason\":\"stop\"}\n";
+    auto msgs = oll::parse_ndjson_for_test(nd, {"remember", "write"});
+    CHECK(count_leaf<StreamToolUseStart>(msgs) == 0);   // not run
+    CHECK(joined_text(msgs).find("remember") == std::string::npos);  // not shown
+}
+
+static void test_ndjson_rescue_tool_from_prose() {
+    // qwen narrates prose AND buries a tool call in a ```sh fenced block. The
+    // terminal rescue scan must find it and salvage it into a real call.
+    std::string nd =
+        "{\"message\":{\"role\":\"assistant\",\"content\":"
+        "\"Sure, I'll rename it.\\n\\n```sh\\n"
+        "{\\\"name\\\": \\\"bash\\\", \\\"arguments\\\": "
+        "{\\\"command\\\":\\\"mv /a /b\\\"}}\\n```\\nDone.\"}}\n"
+        "{\"message\":{\"role\":\"assistant\",\"content\":\"\"},"
+        "\"done\":true,\"done_reason\":\"stop\"}\n";
+    auto msgs = oll::parse_ndjson_for_test(nd, {"bash", "write"});
+    CHECK(count_leaf<StreamToolUseStart>(msgs) == 1);
+    bool saw_args = false;
+    for (const auto& m : msgs)
+        if (const auto* d = get_leaf<StreamToolUseDelta>(m))
+            if (d->partial_json.find("mv /a /b") != std::string::npos) saw_args = true;
+    CHECK(saw_args);
+}
+
+static void test_ndjson_unknown_tool_in_prose_not_salvaged() {
+    // A fenced block naming a NON-advertised tool (qwen hallucinates `git`)
+    // must NOT be salvaged — there's no such tool to call.
+    std::string nd =
+        "{\"message\":{\"role\":\"assistant\",\"content\":"
+        "\"```sh\\n{\\\"name\\\": \\\"git\\\", \\\"arguments\\\": "
+        "{\\\"command\\\":\\\"mv /a /b\\\"}}\\n```\"}}\n"
+        "{\"message\":{\"role\":\"assistant\",\"content\":\"\"},"
+        "\"done\":true,\"done_reason\":\"stop\"}\n";
+    auto msgs = oll::parse_ndjson_for_test(nd, {"bash", "write"});
+    CHECK(count_leaf<StreamToolUseStart>(msgs) == 0);
+}
+
+static void test_ndjson_error_frame() {
+    std::string nd = "{\"error\":\"model not found\"}\n";
+    auto msgs = oll::parse_ndjson_for_test(nd);
+    bool saw_err = false;
+    for (const auto& m : msgs)
+        if (const auto* e = get_leaf<StreamError>(m))
+            if (e->message.find("model not found") != std::string::npos)
+                saw_err = true;
+    CHECK(saw_err);
+}
+
+// ── 3. system_prompt ─────────────────────────────────────────────────────────
+static void test_system_prompt_shape() {
+    auto p = oll::system_prompt();
+    CHECK(p.find("agentty") != std::string::npos);
+    CHECK(p.find("CONVERSATION MEMORY") != std::string::npos);
+    CHECK(p.find("ENVIRONMENT") != std::string::npos);
+    // The verbose Claude prose / big learned-memory dump must NOT be present.
+    CHECK(p.find("<file-editing>") == std::string::npos);
+    CHECK(p.find("<learned-memory") == std::string::npos);
+}
+
+int main() {
+    test_build_messages_text();
+    test_build_messages_tool_calls();
+    test_build_messages_images();
+    test_ndjson_plain_text();
+    test_ndjson_structured_tool_call();
+    test_ndjson_content_salvage_to_tool();
+    test_ndjson_no_tools_means_no_salvage();
+    test_ndjson_footgun_tool_swallowed();
+    test_ndjson_rescue_tool_from_prose();
+    test_ndjson_unknown_tool_in_prose_not_salvaged();
+    test_ndjson_error_frame();
+    test_system_prompt_shape();
+
+    if (g_failures == 0) {
+        std::printf("ollama_transport_test: all checks passed\n");
+        return 0;
+    }
+    std::fprintf(stderr, "ollama_transport_test: %d check(s) failed\n", g_failures);
+    return 1;
+}

--- a/tests/openai_transport_test.cpp
+++ b/tests/openai_transport_test.cpp
@@ -753,6 +753,26 @@ static void test_ndjson_fenced_tool_call_streaming() {
     CHECK(text.find('{') == std::string::npos);
 }
 
+void test_ndjson_empty_object_response() {
+    // qwen2.5-coder:14b outputs {} when tools are passed
+    auto msgs = oai::parse_ndjson_for_test(
+        R"({"message":{"role":"assistant","content":"{}"},"done":false}
+{"message":{"role":"assistant","content":""},"done":true,"done_reason":"stop"}
+)", {"read", "write"});
+    
+    // Should flush {} as text, not show "unparseable"
+    bool found_braces = false;
+    bool found_unparseable = false;
+    for (auto& m : msgs) {
+        if (auto* td = get_leaf<StreamTextDelta>(m)) {
+            if (td->text == "{}") found_braces = true;
+            if (td->text.find("unparseable") != std::string::npos) found_unparseable = true;
+        }
+    }
+    CHECK(found_braces);
+    CHECK(!found_unparseable);
+}
+
 int main() {
     test_build_tools();
     test_build_messages_basic();
@@ -793,6 +813,8 @@ int main() {
     // Streaming fence regression (TODO: streaming case needs more work).
     test_ndjson_fenced_tool_call_simple();
     // test_ndjson_fenced_tool_call_streaming();
+
+    test_ndjson_empty_object_response();
 
     if (g_failures == 0) {
         std::printf("openai_transport_test: all checks passed\n");


### PR DESCRIPTION
## Summary

Adds a native **Ollama provider** alongside the existing OpenAI-compatible and Anthropic backends.

- New `provider/ollama/{provider,transport}` — native `/api/chat` NDJSON streaming path
- Per-provider system-prompt selection in `launch_stream`: Ollama gets its own local-tuned prompt, other OpenAI-compatible backends get the openai local-model prompt, Anthropic keeps the full Claude prompt
- OpenAI transport changes, ACP server + `main.cpp` wiring, catalog updates

## Tests

- New `ollama_transport_test` (288 lines) + `openai_transport_test` additions
- Full suite: **21/21 passing**, clean build with `cmake --build build -j10`

🤖 Generated with agentty