### PR TITLE
feat: --auth-header flag for custom auth header name

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@ All notable changes to agentty. Versions follow [SemVer](https://semver.org/).
 
 ## [Unreleased]
 
+### Added
+- **`--auth-header NAME` — custom auth header for OpenAI-compatible gateways.** Custom `--provider host[:port]` endpoints (and presets) could only authenticate with the hard-coded `Authorization: Bearer <key>`, which locked out self-hosted / enterprise gateways that expect the key under a different header name (e.g. `X-API-Key`). The new session-scoped flag overrides the header *name*; the key (from `-k` / the in-app paste / `OPENAI_API_KEY`) goes out raw under it, on every OpenAI-family request (chat completions, `/v1/models` listing, the Ollama capability probe), and survives live provider switches (`^P`). Unset keeps the standard bearer header; the Anthropic path is untouched. (#5)
+
 ## [0.2.8] - 2026-07-16
 
 ### Fixed

--- a/docs/auth.md
+++ b/docs/auth.md
@@ -17,9 +17,30 @@ CLI flags:
 |---|---|
 | `-k`, `--key KEY` | API-key override for this session |
 | `-m`, `--model ID` | Model id (e.g. `claude-opus-4-5`) |
+| `--auth-header NAME` | Custom auth header name for OpenAI-compatible backends (see below) |
 | `-h`, `--help` | Print usage |
 
 Subcommand dispatch lives in `src/main.cpp:1400-1435`.
+
+## Custom Providers (`--auth-header`)
+
+OpenAI-compatible backends (`--provider openai | groq | … | host[:port]`)
+authenticate with `Authorization: Bearer <key>` by default. Some self-hosted
+or enterprise gateways expect the key under a different header name instead
+(e.g. `X-API-Key`). `--auth-header NAME` overrides the header name for the
+session; the key (from `-k`, the in-app paste, or `OPENAI_API_KEY` /
+provider-specific env var) is sent **raw** under that name — no `Bearer `
+prefix:
+
+```bash
+agentty --provider my-gateway.lan:9000 --auth-header X-API-Key -k sk-xxx
+# emits:  x-api-key: sk-xxx     (instead of authorization: Bearer sk-xxx)
+```
+
+Session-scoped like `-k` (not persisted). Applies to every OpenAI-family
+request — chat completions, model listing, the Ollama capability probe —
+and survives live provider switches (`^P`). The Anthropic path is
+unaffected. Empty/unset keeps the standard bearer header.
 
 ## Authentication Methods
 

--- a/include/agentty/provider/openai/transport.hpp
+++ b/include/agentty/provider/openai/transport.hpp
@@ -63,6 +63,12 @@ struct Endpoint {
     // endpoint applies the model's chat template and answers cleanly. Set
     // for the "ollama" preset only.
     bool        native_api  = false;
+    // Custom auth header NAME (e.g. "X-API-Key") for gateways that don't
+    // accept `Authorization: Bearer`. Empty (the default) keeps the standard
+    // bearer header. When set, the key goes out raw as `<name>: <key>` —
+    // no "Bearer " prefix. Populated from --auth-header via
+    // provider::parse_selection.
+    std::string auth_header_name;
 
     // Built-in presets for the common free / hosted backends. Pass a bare
     // name ("openai", "groq", "openrouter", "together", "cerebras",
@@ -116,6 +122,13 @@ void run_stream_sync(Request req, EventSink sink, http::CancelTokenPtr cancel = 
 // Fetch available models from the endpoint's /v1/models.
 [[nodiscard]] std::vector<ModelInfo> list_models(const AuthHeader& auth,
                                                  const Endpoint& endpoint);
+
+// Common request headers (accept/content-type/user-agent + auth). The auth
+// header is `authorization: Bearer <key>` unless `endpoint.auth_header_name`
+// is set, in which case the key goes out raw under that name. Exposed for
+// tests.
+[[nodiscard]] http::Headers build_request_headers(const AuthHeader& auth,
+                                                  const Endpoint& endpoint);
 
 // Extra system-prompt guidance appended ONLY for OpenAI-compatible backends.
 // Weak local models (Ollama qwen2.5-coder, llama.cpp templates) over-call

--- a/include/agentty/provider/selection.hpp
+++ b/include/agentty/provider/selection.hpp
@@ -38,6 +38,14 @@ struct Selection {
 //   "host[:port]" → OpenAI-compatible against a custom base URL
 [[nodiscard]] Selection parse_selection(std::string_view spec);
 
+// Session-wide custom auth header NAME (--auth-header) for OpenAI-family
+// backends whose gateway doesn't accept `Authorization: Bearer` (e.g.
+// `X-API-Key`). Stored process-globally so every parse_selection — startup
+// AND live provider switches from the picker — stamps it onto the resulting
+// Endpoint. Empty (the default) keeps the standard bearer header.
+void set_custom_auth_header(std::string name);
+[[nodiscard]] std::string custom_auth_header();
+
 // Install the active selection (process-global). Called at startup and by
 // the provider-picker reducer for live switches (UI thread).
 void select(Selection s);

--- a/src/provider/openai/transport.cpp
+++ b/src/provider/openai/transport.cpp
@@ -22,6 +22,7 @@
 #include "agentty/provider/openai/transport.hpp"
 
 #include <algorithm>
+#include <cctype>
 #include <array>
 #include <chrono>
 #include <cstring>
@@ -1298,28 +1299,38 @@ json build_tools(const std::vector<provider::ToolSpec>& tools) {
 }
 
 // ── Header builder ───────────────────────────────────────────────────────────
-namespace {
-http::Headers build_request_headers(const AuthHeader& auth) {
+http::Headers build_request_headers(const AuthHeader& auth,
+                                    const Endpoint& endpoint) {
     http::Headers h;
     h.push_back({"accept", "application/json"});
     h.push_back({"content-type", "application/json"});
     h.push_back({"user-agent", "agentty/" AGENTTY_VERSION});
-    // Both header arms emit `Authorization: Bearer <token>` for the OpenAI
-    // family — OpenAI/Groq/OpenRouter all use bearer keys. (ApiKeyHeader's
-    // raw `sk-...` value goes out the same way; there's no `x-api-key` here.)
+    // Extract the key from either arm — both carry a plain string.
+    std::string key;
     std::visit([&](const auto& a) {
         using T = std::decay_t<decltype(a)>;
-        if constexpr (std::is_same_v<T, ApiKeyHeader>) {
-            if (!a.value.empty())
-                h.push_back({"authorization", "Bearer " + a.value});
-        } else if constexpr (std::is_same_v<T, BearerHeader>) {
-            if (!a.token.empty())
-                h.push_back({"authorization", "Bearer " + a.token});
-        }
+        if constexpr (std::is_same_v<T, ApiKeyHeader>)      key = a.value;
+        else if constexpr (std::is_same_v<T, BearerHeader>) key = a.token;
     }, auth);
+    if (key.empty()) return h;
+    if (!endpoint.auth_header_name.empty()) {
+        // Custom header name (--auth-header): key goes out raw, no "Bearer "
+        // prefix, for gateways that authenticate with e.g. `X-API-Key`.
+        // Lowercased — header names are case-insensitive and every other
+        // header agentty sends is lowercase.
+        std::string name = endpoint.auth_header_name;
+        std::transform(name.begin(), name.end(), name.begin(),
+                       [](unsigned char c) { return std::tolower(c); });
+        h.push_back({std::move(name), std::move(key)});
+    } else {
+        // Default: `Authorization: Bearer <token>` for the whole OpenAI
+        // family — OpenAI/Groq/OpenRouter all use bearer keys. (ApiKeyHeader's
+        // raw `sk-...` value goes out the same way; there's no `x-api-key`
+        // here.)
+        h.push_back({"authorization", "Bearer " + key});
+    }
     return h;
 }
-} // namespace
 
 // ── Streaming entry point ────────────────────────────────────────────────────
 void run_stream_sync(Request req, EventSink sink, http::CancelTokenPtr cancel) {
@@ -1421,7 +1432,7 @@ void run_stream_sync(Request req, EventSink sink, http::CancelTokenPtr cancel) {
         hreq.dial_host = ov.host;
         hreq.dial_port = ov.port;
     }
-    hreq.headers = build_request_headers(req.auth);
+    hreq.headers = build_request_headers(req.auth, req.endpoint);
     hreq.body    = std::move(body_str);
 
     int  http_status = 0;
@@ -1660,7 +1671,7 @@ OllamaProbe probe_ollama_model(const AuthHeader& auth,
     hreq.port       = ep.port;
     hreq.path       = "/api/show";
     hreq.plaintext  = !ep.use_tls;
-    hreq.headers    = build_request_headers(auth);
+    hreq.headers    = build_request_headers(auth, ep);
     hreq.body       = json{{"model", model_name}}.dump();
     hreq.max_body_bytes = 512 * 1024;  // /api/show can be large (modelfile)
 
@@ -1722,7 +1733,7 @@ std::vector<ModelInfo> list_models(const AuthHeader& auth, const Endpoint& endpo
         hreq.dial_host = ov.host;
         hreq.dial_port = ov.port;
     }
-    hreq.headers        = build_request_headers(auth);
+    hreq.headers        = build_request_headers(auth, endpoint);
     hreq.max_body_bytes = 2ull * 1024 * 1024;
 
     http::Timeouts tos;

--- a/src/provider/selection.cpp
+++ b/src/provider/selection.cpp
@@ -15,12 +15,25 @@ namespace {
 Selection  g_active{};
 std::mutex g_active_mu;   // guards g_active across the UI/worker thread split
 
+std::string g_auth_header;         // --auth-header override, "" = Bearer
+std::mutex  g_auth_header_mu;      // same UI/worker split as g_active
+
 std::string env_or_empty(std::string_view name) {
     if (name.empty()) return {};
     const char* v = std::getenv(std::string{name}.c_str());
     return (v && *v) ? std::string{v} : std::string{};
 }
 } // namespace
+
+void set_custom_auth_header(std::string name) {
+    std::lock_guard lk(g_auth_header_mu);
+    g_auth_header = std::move(name);
+}
+
+std::string custom_auth_header() {
+    std::lock_guard lk(g_auth_header_mu);
+    return g_auth_header;
+}
 
 Selection parse_selection(std::string_view spec) {
     Selection s;
@@ -37,6 +50,10 @@ Selection parse_selection(std::string_view spec) {
     s.kind = Kind::OpenAI;
     s.openai_endpoint = openai::Endpoint::from_spec(
         spec.empty() ? default_provider_id() : spec);
+    // Stamp the session's --auth-header override onto every OpenAI-family
+    // endpoint, here rather than at the call sites so live provider switches
+    // (picker / login reducers) keep it without knowing it exists.
+    s.openai_endpoint.auth_header_name = custom_auth_header();
     return s;
 }
 

--- a/src/runtime/main.cpp
+++ b/src/runtime/main.cpp
@@ -118,6 +118,11 @@ void print_usage() {
         "                      like -m. (Switch live in-app with Ctrl-P \xe2\x80\x94 the\n"
         "                      picker has a \"Custom host\xe2\x80\xa6\" entry too.)\n"
         "  -V, --version       Print the agentty version and exit.\n"
+        "      --auth-header N Auth header NAME for OpenAI-compatible backends\n"
+        "                      whose gateway doesn't accept `Authorization:\n"
+        "                      Bearer` (e.g. X-API-Key). The key (-k /\n"
+        "                      OPENAI_API_KEY) is sent raw under that name.\n"
+        "                      Session-scoped like -k; default: Bearer.\n"
         "  -h, --help          Show this message.\n"
         "\n",
         AGENTTY_VERSION);
@@ -131,6 +136,7 @@ struct Args {
     std::string cli_sandbox;   // "auto" | "on" | "off"; empty = auto default
     std::string cli_profile;   // "write" | "ask" | "minimal"; ACP only
     std::string cli_provider;  // "anthropic" | "openai" | "ollama" | "llama.cpp" | host[:port]
+    std::string cli_auth_header; // custom auth header NAME (e.g. "X-API-Key")
     int         airgap_argc = 0;
     char**      airgap_argv = nullptr;   // borrowed from main's argv
     bool        bad = false;
@@ -163,6 +169,8 @@ Args parse_args(int argc, char** argv) {
             out.cli_profile = argv[++i];
         } else if (a == "--provider" && i + 1 < argc) {
             out.cli_provider = argv[++i];
+        } else if (a == "--auth-header" && i + 1 < argc) {
+            out.cli_auth_header = argv[++i];
         } else if (a == "-h" || a == "--help") {
             out.subcommand = "help";
         } else if (a == "-V" || a == "--version" || a == "version") {
@@ -332,6 +340,10 @@ int main(int argc, char** argv) {
         }
         persistence::save_settings(s);
     }
+    // Session-scoped --auth-header override; must be installed BEFORE
+    // parse_selection so the initial Selection (and every live-switch
+    // rebuild) stamps it onto the OpenAI-family Endpoint.
+    provider::set_custom_auth_header(args.cli_auth_header);
     auto selection = provider::parse_selection(provider_spec);
     provider::select(selection);
 

--- a/tests/openai_transport_test.cpp
+++ b/tests/openai_transport_test.cpp
@@ -493,6 +493,57 @@ static void test_endpoint_presets() {
     }
 }
 
+// ── Request headers / --auth-header ─────────────────────────────────────────
+// build_request_headers is the single place the OpenAI-family auth header is
+// emitted (stream, model listing, Ollama probe). Verify the default Bearer
+// arms, the custom-name override, and the empty-key case.
+static void find_header(const agentty::http::Headers& hs, std::string_view name,
+                        const agentty::http::Header** out) {
+    *out = nullptr;
+    for (const auto& h : hs)
+        if (h.name == name) { *out = &h; return; }
+}
+
+static void test_build_request_headers() {
+    oai::Endpoint def;   // no auth_header_name → Bearer
+
+    // Default: both auth arms emit `authorization: Bearer <key>`.
+    const agentty::http::Header* h = nullptr;
+    auto hs = oai::build_request_headers(oai::AuthHeader{oai::ApiKeyHeader{"k1"}}, def);
+    find_header(hs, "authorization", &h);
+    CHECK(h && h->value == "Bearer k1");
+
+    hs = oai::build_request_headers(oai::AuthHeader{oai::BearerHeader{"k2"}}, def);
+    find_header(hs, "authorization", &h);
+    CHECK(h && h->value == "Bearer k2");
+
+    // Custom name: key goes out RAW under the (lowercased) name, and no
+    // authorization header is sent.
+    oai::Endpoint custom;
+    custom.auth_header_name = "X-API-Key";
+    hs = oai::build_request_headers(oai::AuthHeader{oai::ApiKeyHeader{"k3"}}, custom);
+    find_header(hs, "x-api-key", &h);
+    CHECK(h && h->value == "k3");
+    find_header(hs, "authorization", &h);
+    CHECK(h == nullptr);
+
+    // Empty key: no auth header under either scheme (local backends).
+    hs = oai::build_request_headers(oai::AuthHeader{oai::ApiKeyHeader{""}}, custom);
+    find_header(hs, "x-api-key", &h);
+    CHECK(h == nullptr);
+    find_header(hs, "authorization", &h);
+    CHECK(h == nullptr);
+
+    // parse_selection stamps the session override onto the endpoint (and an
+    // empty override leaves it clear).
+    agentty::provider::set_custom_auth_header("Api-Key");
+    auto sel = agentty::provider::parse_selection("my.host:9000");
+    CHECK(sel.openai_endpoint.auth_header_name == "Api-Key");
+    agentty::provider::set_custom_auth_header("");
+    sel = agentty::provider::parse_selection("my.host:9000");
+    CHECK(sel.openai_endpoint.auth_header_name.empty());
+}
+
 // ── Per-preset auth resolution ──────────────────────────────────────────────
 // resolve_auth_for is the single mapping every provider switch goes through
 // (startup AND the picker). Verify each preset kind lands on the right auth:
@@ -904,6 +955,7 @@ int main() {
     test_sse_plain_json_prose_not_salvaged();
     test_sse_structured_tool_still_works_with_salvage_on();
     test_endpoint_presets();
+    test_build_request_headers();
     test_resolve_auth_per_preset();
     // Incremental salvage tests.
     test_sse_salvage_streamed_tokens();


### PR DESCRIPTION
## Summary

Implements #5. OpenAI-compatible custom providers (`--provider host[:port]`) could only authenticate with a hard-coded `Authorization: Bearer <key>` (`src/provider/openai/transport.cpp`), which locks out self-hosted / enterprise gateways that expect the key under a different header name (e.g. `X-API-Key`).

This adds a session-scoped `--auth-header NAME` flag. When set, the key is sent **raw** under that (lowercased) header name instead of the bearer header:

```bash
agentty --provider my-gateway.lan:9000 --auth-header X-API-Key -k sk-xxx
# emits:  x-api-key: sk-xxx     (instead of authorization: Bearer sk-xxx)
```

It's the middle-scope option from #5 (a CLI flag). Easy to extend to a `providers.json` later if you'd prefer that direction.

## How it works

- `Endpoint` gains an `auth_header_name` field (empty = bearer, unchanged behavior).
- `build_request_headers` takes the `Endpoint` and, when the name is set, emits `{lowercased(name), <key>}` raw; otherwise the existing `Authorization: Bearer` arms. Applied at all three call sites (stream, `/v1/models` listing, Ollama `/api/show` probe).
- The name is stored process-globally (`provider::set_custom_auth_header`) and stamped onto the endpoint inside `parse_selection`, so it also survives live provider switches (`^P`) — the picker/login reducers rebuild the `Selection` through `parse_selection`.
- Session-scoped like `-k` (not persisted). Anthropic path untouched.

## Testing

- **Unit** (`tests/openai_transport_test.cpp`, `test_build_request_headers`): default → `authorization: Bearer k`; `auth_header_name = "X-API-Key"` → `x-api-key: k` and no `authorization`; empty key → no auth header; `parse_selection` stamps/clears the override. All checks pass.
- **End-to-end** against a local mock server that echoes received headers:
  - `--auth-header X-API-Key` → request carried `x-api-key: testkey123`, no `authorization`.
  - no flag → `authorization: Bearer testkey123`, no `x-api-key`.

## Docs

`docs/auth.md` (flag table + "Custom Providers" section) and `CHANGELOG.md` under `[Unreleased]`.

Closes #5