### PR TITLE
provider: support full URL specs in --provider for custom path prefixes

### DIFF
--- a/docs/auth.md
+++ b/docs/auth.md
@@ -37,6 +37,18 @@ agentty --provider my-gateway.lan:9000 --auth-header X-API-Key -k sk-xxx
 # emits:  x-api-key: sk-xxx     (instead of authorization: Bearer sk-xxx)
 ```
 
+### Custom path prefix
+
+If the gateway doesn't serve on the standard `/v1` path, specify a full URL instead of a bare `host:port`:
+
+```bash
+agentty --provider https://chat.example.org/api --auth-header X-API-Key -k sk-xxx
+# chats at https://chat.example.org/api/chat/completions
+# auth:   x-api-key: sk-xxx
+```
+
+The URL's path is a prefix — agentty appends `/chat/completions` and `/models`.
+
 Session-scoped like `-k` (not persisted). Applies to every OpenAI-family
 request — chat completions, model listing, the Ollama capability probe —
 and survives live provider switches (`^P`). The Anthropic path is

--- a/docs/website/cli.md
+++ b/docs/website/cli.md
@@ -62,7 +62,7 @@ These mirror `agentty --help` exactly.
 |---|---|
 | `-k`, `--key <key>` | API-key override for this session; never written to disk. |
 | `-m`, `--model <id>` | Model id for the session (e.g. `claude-opus-4-5`). |
-| `--provider <p>` | LLM backend: `anthropic` (default) or an OpenAI-compatible one — `openai` · `groq` · `openrouter` · `together` · `cerebras` · `ollama`, or a raw `host:port`. Persisted like `-m`; switch live with `^P`. See [Providers & Models](/docs/providers). |
+| `--provider <p>` | LLM backend: `anthropic` (default) or an OpenAI-compatible one — `openai` · `groq` · `openrouter` · `together` · `cerebras` · `ollama`, a raw `host:port`, or a full URL `https://host/path` for servers with a custom path prefix. Persisted like `-m`; switch live with `^P`. See [Providers & Models](/docs/providers). |
 | `-p`, `--profile <mode>` | ACP permission tier (Zed shows the prompts): `ask` (default) · `minimal` (also prompt reads) · `write` (never prompts — fully autonomous). |
 | `-w`, `--workspace <dir>` | Sandbox filesystem tools to this directory (default: cwd). Tools refuse paths outside it. Pass `--workspace /` to disable the gate. |
 | `--sandbox <mode>` | Wrap `bash`/`diagnostics` in an OS-native sandbox. `auto` (default) · `on` (require a backend) · `off` (disable). |

--- a/docs/website/providers.md
+++ b/docs/website/providers.md
@@ -42,6 +42,7 @@ Signed in with Claude Pro/Max OAuth, the model picker offers a **"(1M context)"*
 | `cerebras` | Wafer-scale inference — very fast | `CEREBRAS_API_KEY` |
 | `ollama` | Local models at `localhost:11434` | None |
 | `host:port` | Any raw OpenAI-compatible endpoint | `OPENAI_API_KEY` |
+| `https://host[:port]/path` | Any OpenAI-compatible endpoint with a custom path prefix (e.g. a gateway serving on `/api` instead of `/v1`) | `OPENAI_API_KEY` |
 
 ## API keys
 
@@ -54,6 +55,18 @@ agentty --provider groq -m llama-3.3-70b
 # or a one-off, never written to disk:
 agentty --provider openai -k sk-… -m gpt-4o
 ```
+
+### Custom path prefix
+
+Some gateways or self-hosted servers don't serve on the standard `/v1` path. Specify a full URL and agentty will use its path as a prefix, appending `/chat/completions` and `/models`:
+
+```bash
+agentty --provider https://chat.example.org/api -k sk-… -m GLM-5.2
+# chats at  https://chat.example.org/api/chat/completions
+# models at https://chat.example.org/api/models
+```
+
+A bare `host:port` (no `http://`/`https://`) keeps the default `/v1` prefix.
 
 ## Sign in with GitHub Copilot
 

--- a/src/provider/openai/transport.cpp
+++ b/src/provider/openai/transport.cpp
@@ -1111,7 +1111,59 @@ Endpoint Endpoint::from_spec(std::string_view spec) {
         // /v1 (NOT Ollama's native /api/chat), defaults to port 8080, and
         // needs no auth. Plain HTTP — it's a localhost daemon.
         return Endpoint{"localhost", 8080, "/v1/chat/completions",
-                        "/v1/models", false, "llama.cpp"};
+                         "/v1/models", false, "llama.cpp"};
+    }
+    // Full URL form: "https://host[:port][/path]" or "http://host[:port][/path]".
+    // The path is a BASE PREFIX — agentty appends /chat/completions and /models
+    // to it, so "https://gw.example.com/api" → path "/api/chat/completions".
+    // No path after scheme://authority → empty prefix → "/chat/completions".
+    // This lets users reach servers that don't serve on /v1 (e.g. gateways
+    // proxying to /api/chat/completions). Bare "host[:port]" specs (no scheme)
+    // fall through to the legacy handler below and keep the /v1 default.
+    if (spec.starts_with("https://") || spec.starts_with("http://")) {
+        Endpoint ep;
+        ep.label = std::string{spec};
+        std::string_view s{spec};
+        const bool tls = spec.starts_with("https://");
+        ep.use_tls = tls;
+        s.remove_prefix(tls ? 8 : 7);   // "https://" = 8, "http://" = 7
+        ep.port = tls ? 443 : 80;
+
+        // Split authority from path at the first '/'.
+        auto slash = s.find('/');
+        std::string_view authority = (slash == std::string_view::npos)
+            ? s : s.substr(0, slash);
+        std::string prefix;   // base path prefix, may be empty
+        if (slash != std::string_view::npos) {
+            prefix = std::string{s.substr(slash)};
+            // Strip trailing '/' so "/api/" → "/api", and "/" → "".
+            while (prefix.size() > 1 && prefix.back() == '/')
+                prefix.pop_back();
+            if (prefix == "/") prefix.clear();
+        }
+
+        // Split host from port at the last ':' in the authority.
+        auto colon = authority.rfind(':');
+        if (colon != std::string_view::npos) {
+            ep.host = std::string{authority.substr(0, colon)};
+            try {
+                int port_int = std::stoi(std::string{authority.substr(colon + 1)});
+                ep.port = (port_int > 0 && port_int <= 65535)
+                    ? static_cast<std::uint16_t>(port_int)
+                    : (tls ? 443 : 80);
+            }
+            catch (...) { ep.port = tls ? 443 : 80; }
+        } else {
+            ep.host = std::string{authority};
+        }
+
+        // Empty host (e.g. "https:///path" or "https://:443/") → fall back
+        // to the default endpoint rather than dialing an empty host.
+        if (ep.host.empty()) return Endpoint{};
+
+        ep.path       = prefix + "/chat/completions";
+        ep.models_path = prefix + "/models";
+        return ep;
     }
     // Treat anything else as a raw "host[:port]" — defaults to https on 443,
     // plain http if a non-443 port is given (a local server convention).

--- a/tests/openai_transport_test.cpp
+++ b/tests/openai_transport_test.cpp
@@ -523,6 +523,90 @@ static void test_endpoint_presets() {
     CHECK(def.host == "api.openai.com");
     CHECK(def.use_tls);
 
+    // ── Full URL specs (http:// or https:// prefix) ──────────────
+    // A URL spec lets the user pick a custom path prefix for servers
+    // that don't serve on /v1 (e.g. chat.example.org serves on
+    // /api/chat/completions). The path in the URL is a BASE PREFIX;
+    // agentty appends /chat/completions and /models to it.
+    {
+        auto url = oai::Endpoint::from_spec("https://chat.example.org/api");
+        CHECK(url.host == "chat.example.org");
+        CHECK(url.port == 443);
+        CHECK(url.use_tls);
+        CHECK(url.path == "/api/chat/completions");
+        CHECK(url.models_path == "/api/models");
+        CHECK(!url.native_api);
+        CHECK(url.label == "https://chat.example.org/api");
+    }
+    {
+        auto url = oai::Endpoint::from_spec("http://localhost:8080/custom");
+        CHECK(url.host == "localhost");
+        CHECK(url.port == 8080);
+        CHECK(!url.use_tls);
+        CHECK(url.path == "/custom/chat/completions");
+        CHECK(url.models_path == "/custom/models");
+    }
+    {
+        // No path after scheme://authority → empty prefix → /chat/completions
+        auto url = oai::Endpoint::from_spec("https://my-gateway.com");
+        CHECK(url.host == "my-gateway.com");
+        CHECK(url.port == 443);
+        CHECK(url.use_tls);
+        CHECK(url.path == "/chat/completions");
+        CHECK(url.models_path == "/models");
+    }
+    {
+        // Trailing slash on the prefix is stripped before appending.
+        auto url = oai::Endpoint::from_spec("https://host:9000/prefix/");
+        CHECK(url.host == "host");
+        CHECK(url.port == 9000);
+        CHECK(url.use_tls);
+        CHECK(url.path == "/prefix/chat/completions");
+        CHECK(url.models_path == "/prefix/models");
+    }
+    {
+        // http:// with explicit port and no path.
+        auto url = oai::Endpoint::from_spec("http://10.0.0.5:5000");
+        CHECK(url.host == "10.0.0.5");
+        CHECK(url.port == 5000);
+        CHECK(!url.use_tls);
+        CHECK(url.path == "/chat/completions");
+        CHECK(url.models_path == "/models");
+    }
+    {
+        // Invalid port (non-numeric) → falls back to scheme default.
+        auto url = oai::Endpoint::from_spec("https://host:abc/path");
+        CHECK(url.host == "host");
+        CHECK(url.port == 443);
+        CHECK(url.use_tls);
+        CHECK(url.path == "/path/chat/completions");
+    }
+    {
+        // Out-of-range port → falls back to scheme default.
+        auto url = oai::Endpoint::from_spec("http://host:99999/path");
+        CHECK(url.host == "host");
+        CHECK(url.port == 80);
+        CHECK(!url.use_tls);
+        CHECK(url.path == "/path/chat/completions");
+    }
+    {
+        // Empty host (e.g. "https:///path") → falls back to default endpoint.
+        auto url = oai::Endpoint::from_spec("https:///path");
+        CHECK(url.host == "api.openai.com");
+        CHECK(url.port == 443);
+        CHECK(url.use_tls);
+    }
+    {
+        // Backward compat: bare host:port (no scheme) still uses /v1 default.
+        auto noscheme = oai::Endpoint::from_spec("my.host:8080");
+        CHECK(noscheme.host == "my.host");
+        CHECK(noscheme.port == 8080);
+        CHECK(!noscheme.use_tls);
+        CHECK(noscheme.path == "/v1/chat/completions");
+        CHECK(noscheme.models_path == "/v1/models");
+        CHECK(noscheme.label == "my.host:8080");
+    }
+
     // Registry ↔ from_spec consistency: EVERY OpenAI-family preset id must
     // resolve to a usable endpoint (non-empty host + chat/models paths).
     // Anthropic is skipped — it doesn't go through the OpenAI from_spec.


### PR DESCRIPTION
Endpoint::from_spec() previously hardcoded /v1/chat/completions for all custom host:port endpoints, causing HTTP 405 on servers that use a different path prefix.

Add a URL-parsing branch that activates when the spec starts with http:// or https://. The URL path is treated as a base prefix — agentty appends /chat/completions and /models to it, mirroring how opencode's @ai-sdk/openai-compatible baseURL works.

Examples:
  --provider https://chat.logistik.systems/api
    → chats at /api/chat/completions, models at /api/models
  --provider http://localhost:8080/custom
    → chats at /custom/chat/completions
  --provider https://my-gateway.com (no path)
    → chats at /chat/completions (no /v1 prefix)

Bare host:port specs (no scheme) are unchanged — they keep the /v1 default for full backward compatibility.

Includes: empty-host guard (falls back to default endpoint), invalid/out- of-range port fallback to scheme default, trailing-slash stripping, and 9 test cases covering all paths. Documentation updated in providers.md, cli.md, and auth.md.