### PR TITLE
fix(tui): restore CLI/TUI parity for custom-host providers

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2093,6 +2093,14 @@ if(AGENTTY_BUILD_TESTS)
     agentty_add_full_test(codex_login_flow_test)
     set_tests_properties(codex_login_flow_test PROPERTIES TIMEOUT 30)
 
+    # custom_host_key_prompt_test — the CustomHostInput → ApiKeyInput handoff
+    # for TLS custom hosts: a remote https://host/path prompts for an API key
+    # before committing the switch; a local http://host:port or bare host:port
+    # commits keyless as before. Esc at the key prompt cancels the switch.
+    # Pure reducer test: stubs deps() with an in-memory store::Settings.
+    agentty_add_full_test(custom_host_key_prompt_test)
+    set_tests_properties(custom_host_key_prompt_test PROPERTIES TIMEOUT 30)
+
     # command_palette_test — the Ctrl+K palette catalog + filter UX. Pure
     # header logic (kCommands + filtered_commands): pins the enum⇄row
     # bijection (no dead palette entries), that every row has a label +
@@ -2397,6 +2405,7 @@ if(AGENTTY_BUILD_TESTS)
         tool_stream_snapshot_test
         persistence_proactive_test
         codex_login_flow_test
+        custom_host_key_prompt_test
         command_palette_test
         code_block_extract_test
         smart_mode_test

--- a/src/provider/selection.cpp
+++ b/src/provider/selection.cpp
@@ -132,7 +132,36 @@ std::string provider_display_name(const Selection& s) {
     // registry display name; fall back to the raw label for a custom host.
     const std::string& lbl = s.openai_endpoint.label;
     if (const auto* p = preset_for(lbl)) return std::string{p->label};
-    return lbl.empty() ? std::string{"OpenAI"} : lbl;
+    if (lbl.empty()) return std::string{"OpenAI"};
+    // URL-form custom hosts (https://host/path, http://host:port/path) carry
+    // the full spec as their label (see Endpoint::from_spec). The badge and
+    // the switch toast should show host[:port], not the long URL. ep.label itself
+    // is untouched — preset lookup and the openai_transport_test label
+    // round-trip assertion still see the full spec.
+    if (lbl.starts_with("https://") || lbl.starts_with("http://")) {
+        const bool tls = lbl.starts_with("https://");
+        std::string_view s = lbl;
+        s.remove_prefix(tls ? 8 : 7);   // "https://" = 8, "http://" = 7
+        // Strip path at first '/' (everything after the authority).
+        if (auto slash = s.find('/'); slash != std::string_view::npos)
+            s = s.substr(0, slash);
+        // Split host / port at the last ':'.
+        std::string out;
+        std::uint16_t port = tls ? 443 : 80;
+        if (auto colon = s.rfind(':'); colon != std::string_view::npos) {
+            out = std::string{s.substr(0, colon)};
+            try {
+                int p = std::stoi(std::string{s.substr(colon + 1)});
+                if (p > 0 && p <= 65535) port = static_cast<std::uint16_t>(p);
+            } catch (...) {}
+        } else {
+            out = std::string{s};
+        }
+        // Omit the port when it's the scheme default.
+        if (port != (tls ? 443 : 80)) out += ":" + std::to_string(port);
+        return out;
+    }
+    return lbl;
 }
 
 PrewarmTarget prewarm_target(const Selection& s) {

--- a/src/runtime/app/update/login.cpp
+++ b/src/runtime/app/update/login.cpp
@@ -475,30 +475,70 @@ Step login_submit(Model m) {
         while (!spec.empty() && (spec.back() == '\r' || spec.back() == '\n'
                                || spec.back() == ' ' || spec.back() == '\t'))
             spec.pop_back();
-        // Strip a leading scheme if the user pasted a URL — from_spec wants
-        // a bare host[:port].
-        for (std::string_view pfx : {"http://", "https://"})
-            if (spec.rfind(pfx, 0) == 0) { spec.erase(0, pfx.size()); break; }
-        // Trim a trailing slash / path — only host[:port] is meaningful.
-        if (auto slash = spec.find('/'); slash != std::string::npos)
-            spec.erase(slash);
         if (spec.empty()) {
             m.ui.login = login::Failed{"no host entered"};
             return done(std::move(m));
         }
 
-        // Custom hosts are treated as keyless local/compatible endpoints;
-        // resolve_auth_for still consults the OPENAI_API_KEY chain in case
-        // the user is fronting a keyed proxy. Load Anthropic creds fresh from
-        // disk (NOT deps().auth) so resolve_auth_for never echoes the current
-        // provider's empty key — same footgun the picker guards against.
+        // Remote (TLS) custom hosts need an API key — local servers
+        // (http://, bare host:port) conventionally don't. For TLS hosts,
+        // hand off to the ApiKeyInput modal instead of committing immediately:
+        // the user pastes a key, it's saved to provider_keys[spec], and the
+        // existing ApiKeyInput arm commits the switch. Esc at the key prompt
+        // dispatches CloseLogin → no switch (matching how Esc works for
+        // every other login sub-state). For non-TLS hosts, fall through to
+        // the keyless commit path below.
+        const bool needs_key = provider::parse_selection(spec)
+                                   .openai_endpoint.use_tls;
+        if (needs_key) {
+            std::string label = provider::provider_display_name(
+                provider::parse_selection(spec));
+            // Pre-fill the key field with any key already saved for this
+            // spec so re-entering a known host shows its current key (masked)
+            // for confirmation/edit, not a blank field.
+            std::string existing_key;
+            {
+                auto settings = deps().load_settings();
+                if (auto it = settings.provider_keys.find(spec);
+                    it != settings.provider_keys.end())
+                    existing_key = it->second;
+            }
+            // Capture size BEFORE the move: designated initializers evaluate
+            // in declaration order (key_input before cursor), so
+            // std::move(existing_key) into .key_input would leave
+            // existing_key moved-from when .cursor reads .size().
+            const int key_len = static_cast<int>(existing_key.size());
+            m.ui.login = login::ApiKeyInput{
+                .key_input      = std::move(existing_key),
+                .cursor         = key_len,
+                .provider       = spec,
+                .provider_label = std::move(label),
+            };
+            return done(std::move(m));
+        }
+
+        // Non-TLS (local) host: no key needed. Resolve auth (will be empty
+        // for local servers, which is correct — list_models only short-
+        // circuits on use_tls && is_empty(auth)) and commit immediately.
+        // Reuse provider_keys[spec] if present (a keyed local proxy the
+        // user previously configured); otherwise the OPENAI_API_KEY chain
+        // is consulted as a fallback.
         auth::AuthHeader anthropic_creds = deps().auth;
         if (auto saved = auth::load_credentials())
             anthropic_creds = auth::make_auth_header(*saved);
-        auth::AuthHeader new_auth =
-            provider::resolve_auth_for(spec, anthropic_creds);
+        std::string saved_provider_key;
+        {
+            auto settings = deps().load_settings();
+            if (auto it = settings.provider_keys.find(spec);
+                it != settings.provider_keys.end())
+                saved_provider_key = it->second;
+        }
+        auth::AuthHeader new_auth = provider::resolve_auth_for(
+            spec, anthropic_creds, /*cli_key=*/{}, saved_provider_key);
         m.ui.login = login::Closed{};
-        return commit_provider_switch(std::move(m), spec, std::move(new_auth), spec);
+        return commit_provider_switch(std::move(m), spec, std::move(new_auth),
+                                      provider::provider_display_name(
+                                          provider::parse_selection(spec)));
     }
     if (auto* api = std::get_if<login::ApiKeyInput>(&m.ui.login)) {
         std::string key = std::move(api->key_input);

--- a/src/runtime/view/login.cpp
+++ b/src/runtime/view/login.cpp
@@ -381,7 +381,9 @@ Element panel_custom_host(const login::CustomHostInput& s) {
         "Enter a host or host:port for any server that speaks the OpenAI "
         "chat API \xe2\x80\x94 llama.cpp, vLLM, LM Studio, a proxy, or a "
         "remote box. A non-443 port uses plain HTTP (the local-server "
-        "convention); a bare host uses HTTPS on 443.",
+        "convention); a bare host uses HTTPS on 443. For a server that "
+        "serves on a path prefix instead of /v1, paste the full URL "
+        "(https://host/path) and the prefix will be honoured.",
         fg_dim(muted)));
     rows.push_back(text(""));
     rows.push_back(input_row(s.host_input, s.cursor, /*secret=*/false,
@@ -389,7 +391,7 @@ Element panel_custom_host(const login::CustomHostInput& s) {
     rows.push_back(text(""));
     rows.push_back(body_text(
         "Examples:  localhost:8080  \xc2\xb7  127.0.0.1:1234  \xc2\xb7  "
-        "inference.example.com",
+        "inference.example.com  \xc2\xb7  https://inference.example.com/api",
         fg_dim(muted)));
     rows.push_back(text(""));
     rows.push_back(key_hints({{"Enter", "connect"}, {"Esc", "cancel"}}));

--- a/tests/custom_host_key_prompt_test.cpp
+++ b/tests/custom_host_key_prompt_test.cpp
@@ -1,0 +1,186 @@
+// custom_host_key_prompt_test — the CustomHostInput → ApiKeyInput handoff for
+// TLS custom hosts. A remote https://host/path needs an API key before the
+// provider switch commits; a local http://host:port or bare host:port commits
+// keyless as before. Esc at the key prompt cancels the whole switch.
+//
+// Pure reducer test: stubs deps() with an in-memory store::Settings and
+// sets XDG_CONFIG_HOME to a temp dir so auth::load_credentials() returns
+// nullopt (no on-disk creds interfere with the non-TLS path). The test
+// detects whether commit_provider_switch ran via m.s.models_loading (which
+// commit_provider_switch sets at modal.cpp:691) — same indirection
+// codex_login_flow_test uses for the ChatGPT path.
+//
+// Run: build the `custom_host_key_prompt_test` target, execute. Exit 0 = pass.
+
+#include "agentty/runtime/app/update/internal.hpp"
+#include "agentty/runtime/app/deps.hpp"
+#include "agentty/runtime/login.hpp"
+#include "agentty/runtime/model.hpp"
+#include "agentty/runtime/msg.hpp"
+#include "agentty/store/store.hpp"
+#include "agentty/provider/selection.hpp"
+
+#include <cstdio>
+#include <cstdlib>
+#include <filesystem>
+#include <string>
+
+namespace fs = std::filesystem;
+namespace login = agentty::ui::login;
+namespace msg = agentty::msg;
+namespace app = agentty::app;
+
+static int g_checks = 0;
+static int g_fails  = 0;
+static void check(bool ok, const char* what) {
+    ++g_checks;
+    if (!ok) { ++g_fails; std::printf("FAIL: %s\n", what); }
+    else     { std::printf("ok:   %s\n", what); }
+}
+
+// Helper: install deps() with an in-memory Settings captured by reference.
+// The other Deps members are stubbed to no-ops since login_submit's
+// CustomHostInput arm only calls deps().load_settings() and deps().auth.
+static void install_stub_deps(agentty::store::Settings& s) {
+    app::install_deps(app::Deps{
+        .stream         = [](auto, auto) {},
+        .save_thread    = [](const auto&) {},
+        .load_threads   = [] { return std::vector<agentty::Thread>{}; },
+        .load_thread    = [](const auto&) -> std::optional<agentty::Thread> { return std::nullopt; },
+        .load_settings  = [&s] { return s; },
+        .save_settings  = [&s](const agentty::store::Settings& x) { s = x; },
+        .new_thread_id  = [] { return agentty::ThreadId{}; },
+        .title_from     = [](std::string_view t) { return std::string{t}; },
+        .auth           = agentty::auth::AuthHeader{agentty::auth::ApiKeyHeader{std::string{}}},
+    });
+}
+
+int main() {
+    std::printf("custom_host_key_prompt_test\n");
+
+    // Redirect XDG_CONFIG_HOME to a temp dir with no agentty/ subdir so
+    // auth::load_credentials() returns nullopt (no credentials.json exists).
+    // This keeps the non-TLS path deterministic regardless of the host env.
+    fs::path tmp_xdg = fs::temp_directory_path() /
+        ("agentty-test-" + std::to_string(::getpid()));
+    std::error_code mkdir_ec;
+    fs::create_directories(tmp_xdg, mkdir_ec);
+    ::setenv("XDG_CONFIG_HOME", tmp_xdg.c_str(), 1);
+    // Ensure parse_selection's custom_auth_header() read is deterministic.
+    agentty::provider::set_custom_auth_header("");
+
+    // ── Case 1: TLS host, no saved key → ApiKeyInput with empty key field ──
+    {
+        agentty::store::Settings s;
+        install_stub_deps(s);
+        agentty::Model m;
+        m.ui.login = login::CustomHostInput{.host_input = "https://chat.example.org/api"};
+        auto [m2, cmd] = app::detail::login_update(
+            std::move(m), msg::LoginMsg{agentty::LoginSubmit{}});
+        auto* api = std::get_if<login::ApiKeyInput>(&m2.ui.login);
+        check(api != nullptr,
+              "1: TLS host transitions to ApiKeyInput (not committed)");
+        check(api && api->provider == "https://chat.example.org/api",
+              "1: ApiKeyInput.provider is the full URL spec (persistence key)");
+        check(api && api->provider_label == "chat.example.org",
+              "1: ApiKeyInput.provider_label is the host-only display name");
+        check(api && api->key_input.empty(),
+              "1: key_input is empty (no saved key to pre-fill)");
+        check(api && api->cursor == 0,
+              "1: cursor at 0 for empty key field");
+        // commit_provider_switch did NOT run: models_loading stays false.
+        check(!m2.s.models_loading,
+              "1: no commit (models_loading false)");
+        (void)cmd;
+    }
+
+    // ── Case 2: TLS host, saved key exists → ApiKeyInput pre-filled ──
+    {
+        agentty::store::Settings s;
+        s.provider_keys["https://chat.example.org/api"] = "sk-test-key";
+        install_stub_deps(s);
+        agentty::Model m;
+        m.ui.login = login::CustomHostInput{.host_input = "https://chat.example.org/api"};
+        auto [m2, cmd] = app::detail::login_update(
+            std::move(m), msg::LoginMsg{agentty::LoginSubmit{}});
+        auto* api = std::get_if<login::ApiKeyInput>(&m2.ui.login);
+        check(api != nullptr,
+              "2: TLS host with saved key still transitions to ApiKeyInput");
+        check(api && api->key_input == "sk-test-key",
+              "2: key_input pre-filled with the saved key (2a)");
+        check(api && api->cursor == 11,
+              "2: cursor at end of pre-filled key (sk-test-key = 11 chars)");
+        check(!m2.s.models_loading,
+              "2: no commit (waiting for key submit)");
+        (void)cmd;
+    }
+
+    // ── Case 3: Non-TLS bare host:port → commit immediately, no key prompt ──
+    {
+        agentty::store::Settings s;
+        install_stub_deps(s);
+        agentty::Model m;
+        // Seed available_models so we can detect it being cleared by commit.
+        m.d.available_models.push_back(agentty::ModelInfo{
+            .id = agentty::ModelId{"old-model"}, .display_name = "old"});
+        m.ui.login = login::CustomHostInput{.host_input = "localhost:8080"};
+        auto [m2, cmd] = app::detail::login_update(
+            std::move(m), msg::LoginMsg{agentty::LoginSubmit{}});
+        check(std::holds_alternative<login::Closed>(m2.ui.login),
+              "3: non-TLS host commits (modal closes, not ApiKeyInput)");
+        check(m2.s.models_loading,
+              "3: commit_provider_switch ran (models_loading true)");
+        check(m2.d.available_models.empty(),
+              "3: commit_provider_switch cleared available_models");
+        (void)cmd;
+    }
+
+    // ── Case 4: Non-TLS http://host:port/path → commit, no key prompt ──
+    {
+        agentty::store::Settings s;
+        install_stub_deps(s);
+        agentty::Model m;
+        m.d.available_models.push_back(agentty::ModelInfo{
+            .id = agentty::ModelId{"old-model"}, .display_name = "old"});
+        m.ui.login = login::CustomHostInput{.host_input = "http://10.0.0.5:5000/custom"};
+        auto [m2, cmd] = app::detail::login_update(
+            std::move(m), msg::LoginMsg{agentty::LoginSubmit{}});
+        check(std::holds_alternative<login::Closed>(m2.ui.login),
+              "4: http:// host commits (modal closes)");
+        check(m2.s.models_loading,
+              "4: commit_provider_switch ran (models_loading true)");
+        check(m2.d.available_models.empty(),
+              "4: commit_provider_switch cleared available_models");
+        (void)cmd;
+    }
+
+    // ── Case 5: Esc at the key prompt → cancel the whole switch ──
+    {
+        agentty::store::Settings s;
+        install_stub_deps(s);
+        agentty::Model m;
+        // First submit a TLS host to land in ApiKeyInput.
+        m.ui.login = login::CustomHostInput{.host_input = "https://chat.example.org/api"};
+        auto [m1, cmd1] = app::detail::login_update(
+            std::move(m), msg::LoginMsg{agentty::LoginSubmit{}});
+        check(std::holds_alternative<login::ApiKeyInput>(m1.ui.login),
+              "5: setup — TLS host entered ApiKeyInput");
+        // Now press Esc (CloseLogin).
+        auto [m2, cmd2] = app::detail::login_update(
+            std::move(m1), msg::LoginMsg{agentty::CloseLogin{}});
+        check(std::holds_alternative<login::Closed>(m2.ui.login),
+              "5: Esc at key prompt closes the modal");
+        check(!m2.s.models_loading,
+              "5: no commit happened (models_loading false)");
+        (void)cmd1; (void)cmd2;
+    }
+
+    // Cleanup the temp XDG dir.
+    std::error_code ec;
+    fs::remove_all(tmp_xdg, ec);
+
+    std::printf("%d checks, %d failures\n", g_checks, g_fails);
+    if (g_fails == 0) { std::printf("PASSED\n"); return 0; }
+    std::printf("FAILED\n");
+    return 1;
+}

--- a/tests/openai_transport_test.cpp
+++ b/tests/openai_transport_test.cpp
@@ -633,6 +633,109 @@ static void test_endpoint_presets() {
     }
 }
 
+// ── provider_display_name: URL-form labels collapse to host[:port] ──
+// A custom OpenAI-compatible host entered as "https://chat.example.org/api"
+// has Endpoint::label == the full URL (see Endpoint::from_spec, transport.cpp).
+// The badge/toast should read "chat.example.org", not the long URL. Default
+// port for the scheme is omitted; a non-default port is kept ("host:port").
+static void test_provider_display_name_url_label() {
+    namespace P = agentty::provider;
+    using oai::Endpoint;
+
+    {
+        P::Selection s;
+        s.kind = P::Kind::OpenAI;
+        s.openai_endpoint = Endpoint::from_spec("https://chat.example.org/api");
+        // Sanity: from_spec built the URL-form endpoint as designed.
+        CHECK(s.openai_endpoint.host == "chat.example.org");
+        CHECK(s.openai_endpoint.port == 443);
+        CHECK(s.openai_endpoint.use_tls);
+        CHECK(s.openai_endpoint.path == "/api/chat/completions");
+        // label stays the full URL (preset lookup keys on it); display collapses.
+        CHECK(s.openai_endpoint.label == "https://chat.example.org/api");
+        CHECK(P::provider_display_name(s) == "chat.example.org");
+    }
+    {
+        // Non-default https port: keep host:port.
+        P::Selection s;
+        s.kind = P::Kind::OpenAI;
+        s.openai_endpoint = Endpoint::from_spec("https://host:9000/prefix/");
+        CHECK(P::provider_display_name(s) == "host:9000");
+    }
+    {
+        // http:// with non-default port: keep host:port (80 IS default for http,
+        // so http://host:80 → "host", not "host:80").
+        P::Selection s;
+        s.kind = P::Kind::OpenAI;
+        s.openai_endpoint = Endpoint::from_spec("http://10.0.0.5:5000");
+        CHECK(P::provider_display_name(s) == "10.0.0.5:5000");
+    }
+    {
+        // http:// with default port 80: collapse to bare host.
+        P::Selection s;
+        s.kind = P::Kind::OpenAI;
+        s.openai_endpoint = Endpoint::from_spec("http://10.0.0.5:80");
+        CHECK(P::provider_display_name(s) == "10.0.0.5");
+    }
+    {
+        // Bare host[:port] (no scheme) label is unchanged: passes through.
+        P::Selection s;
+        s.kind = P::Kind::OpenAI;
+        s.openai_endpoint = Endpoint::from_spec("my.host:8080");
+        CHECK(s.openai_endpoint.label == "my.host:8080");
+        CHECK(P::provider_display_name(s) == "my.host:8080");
+    }
+}
+
+// ── TUI custom-host submit: the spec string must round-trip unchanged ──
+// login_submit's CustomHostInput arm used to strip the URL scheme and trim
+// the path, which broke https://host/api → /v1/chat/completions. After the
+// fix the raw spec flows into parse_selection → from_spec. This pins the
+// contract for the specs the TUI must accept: every URL form a CLI user
+// can pass via --provider, plus bare host[:port].
+static void test_tui_custom_host_specs() {
+    namespace P = agentty::provider;
+
+    // The exact spec the user reported broken.
+    {
+        auto sel = P::parse_selection("https://chat.example.org/api");
+        CHECK(sel.kind == P::Kind::OpenAI);
+        CHECK(sel.openai_endpoint.host == "chat.example.org");
+        CHECK(sel.openai_endpoint.port == 443);
+        CHECK(sel.openai_endpoint.use_tls);
+        CHECK(sel.openai_endpoint.path == "/api/chat/completions");
+        CHECK(sel.openai_endpoint.models_path == "/api/models");
+    }
+    // http:// with explicit port and path prefix.
+    {
+        auto sel = P::parse_selection("http://localhost:8080/custom");
+        CHECK(sel.kind == P::Kind::OpenAI);
+        CHECK(sel.openai_endpoint.host == "localhost");
+        CHECK(sel.openai_endpoint.port == 8080);
+        CHECK(!sel.openai_endpoint.use_tls);
+        CHECK(sel.openai_endpoint.path == "/custom/chat/completions");
+        CHECK(sel.openai_endpoint.models_path == "/custom/models");
+    }
+    // https:// with no path → empty prefix → /chat/completions (not /v1/...).
+    {
+        auto sel = P::parse_selection("https://my-gateway.com");
+        CHECK(sel.kind == P::Kind::OpenAI);
+        CHECK(sel.openai_endpoint.host == "my-gateway.com");
+        CHECK(sel.openai_endpoint.path == "/chat/completions");
+        CHECK(sel.openai_endpoint.models_path == "/models");
+    }
+    // Bare host[:port] (legacy TUI behaviour) → /v1 default, unchanged.
+    {
+        auto sel = P::parse_selection("localhost:8080");
+        CHECK(sel.kind == P::Kind::OpenAI);
+        CHECK(sel.openai_endpoint.host == "localhost");
+        CHECK(sel.openai_endpoint.port == 8080);
+        CHECK(!sel.openai_endpoint.use_tls);
+        CHECK(sel.openai_endpoint.path == "/v1/chat/completions");
+        CHECK(sel.openai_endpoint.models_path == "/v1/models");
+    }
+}
+
 // ── Request headers / --auth-header ─────────────────────────────────────────
 // build_request_headers is the single place the OpenAI-family auth header is
 // emitted (stream, model listing, Ollama probe). Verify the default Bearer
@@ -1183,6 +1286,8 @@ int main() {
     test_sse_plain_json_prose_not_salvaged();
     test_sse_structured_tool_still_works_with_salvage_on();
     test_endpoint_presets();
+    test_provider_display_name_url_label();
+    test_tui_custom_host_specs();
     test_build_request_headers();
     test_resolve_auth_per_preset();
     // Incremental salvage tests.


### PR DESCRIPTION
Two bugs in the TUI custom-host modal (CustomHostInput) prevented it from reaching remote https://host/path servers, causing 404s or an empty model picker while the CLI --provider flag worked fine.

1. URL stripping: login_submit erased the http(s):// scheme and trimmed everything after the first '/', so https://host/api dialed /v1/chat/completions instead of /api/chat/completions and 404'd. Endpoint::from_spec already supported full URL specs (and was unit- tested for them); the stripping fought that capability. Fix: pass the raw spec through unchanged to parse_selection/from_spec, matching the CLI --provider path exactly.

2. Key entry: the modal collected only the host, never an API key. For TLS hosts list_models short-circuits on use_tls && is_empty(auth), so /api/models returned nothing and the picker showed 'No models available'. Fix: when the submitted host has use_tls == true, transition to the existing ApiKeyInput state instead of committing keyless. The user pastes a key, it's saved to provider_keys[spec] (the same persistence key the auth lookup reads), and the existing ApiKeyInput arm commits the switch. The key field is pre-filled from provider_keys[spec] on re-entry (masked as ****), so re-entering a known host shows its current key for confirmation/edit. Esc at the key prompt cancels the whole switch via the existing CloseLogin routing. Non-TLS hosts (http://, bare host:port) keep the keyless commit path unchanged — local servers conventionally need no key.

provider_display_name collapses URL-form labels (https://host/path) to host[:port] for the status-bar badge and the switch toast, so they read 'host' instead of the full URL. ep.label itself is untouched so preset lookup and the label round-trip test still see the full spec.

panel_custom_host advertises that a full https://host/path URL is accepted for path-prefixed servers, with a URL example added to the examples line. Placeholder stays 'localhost:8080' for the common local case.

Tests:
- openai_transport_test: test_provider_display_name_url_label (5 cases for the label collapse) + test_tui_custom_host_specs (4 cases pinning the parse_selection/from_spec contract the reducer must forward unchanged, including https://host/api, http://host:port/path, https://host no-path, and bare host:port).
- custom_host_key_prompt_test (new): 5 cases covering TLS transition to ApiKeyInput, key pre-fill from provider_keys[spec], non-TLS keyless commit, and Esc cancel. Stubs deps() with an in-memory store::Settings and redirects XDG_CONFIG_HOME for determinism.