### PR TITLE
feat(prompt): inject AGENTS.md (AAIF standard) ahead of CLAUDE.md tiers

### DIFF
--- a/cmake/AgenttyTests.cmake
+++ b/cmake/AgenttyTests.cmake
@@ -44,6 +44,11 @@ agentty_test(fork_test               MODE standalone TIMEOUT 30)
 agentty_test(reveal_freeze_gate_probe MODE standalone TIMEOUT 30)
 agentty_test(toolset_e2e_test        MODE standalone TIMEOUT 120)
 agentty_test(subagent_report_test    MODE standalone TIMEOUT 60)
+# agents_md_test — locks wire::agents_md_block (AAIF AGENTS.md standard,
+# project-scoped). Standalone (own main(), touches fs:: for temp workspaces)
+# rather than consolidated; not sanitizer-labelled because it links the
+# shared object set that pulls maya::maya (ODR-clashes under asan).
+agentty_test(agents_md_test          MODE standalone TIMEOUT 30)
 agentty_test(plugin_disabled_tools_test MODE standalone TIMEOUT 60)
 agentty_test(frozen_invariant_fuzz   MODE standalone)
 agentty_test(scrollback_wire_fuzz    MODE standalone TIMEOUT 120)

--- a/docs/website/configuration.md
+++ b/docs/website/configuration.md
@@ -100,6 +100,16 @@ On the Claude backend, agentty appends up to three user-authored guidance files 
 - `<project>/CLAUDE.md` — project tier.
 - `<project>/CLAUDE.local.md` — local tier (gitignore it for personal notes).
 
+## AGENTS.md guidance
+
+agentty also reads the [AGENTS.md](https://agents.md) open standard — stewarded by the [Agentic AI Foundation](https://aaif.io) under the Linux Foundation — for project-scoped agent guidance. Think of AGENTS.md as a README for agents: a dedicated, predictable place to provide build steps, test commands, and code-style conventions to AI coding agents. Over 60k open-source projects ship one.
+
+Per the published spec, AGENTS.md is **project-scoped only**: agentty reads a single file at `<project>/AGENTS.md` (resolved from `--workspace`, not the raw process cwd). There is no user tier and no local tier — those concerns stay with CLAUDE.md. agentty's workspace model is single-tier, so nested per-subpackage AGENTS.md files (allowed by the spec for monorepos) are not walked; only the project-root file is read.
+
+When AGENTS.md is present, agentty injects it as its own `<agents-md>` block in the system prompt — placed **before** the CLAUDE.md `<memory>` block, so standardized public project guidance lands first and personal/team memory layers on top. Each file is capped at 64 KiB and mtime-cached (same pipeline as CLAUDE.md). The block is elided entirely when the file is missing or empty, so adding AGENTS.md is purely additive — workspaces without one see no change.
+
+Coexistence with CLAUDE.md is intentional: AGENTS.md is the cross-tool public standard (works with Codex, Cursor, Jules, Aider, opencode, and many others — see the [full list](https://agents.md)), while CLAUDE.md remains agentty's personal/team memory hierarchy. A repo can ship AGENTS.md for cross-agent conventions and individual users can keep CLAUDE.md / CLAUDE.local.md for their own notes; both are injected, AGENTS.md first.
+
 ## Persisted settings
 
 `--provider`, `-m`/`--model`, the reasoning effort tier, favourited models, your permission profile, and your compaction depth are written to `~/.agentty/settings.json` whenever you change them in-app — so the next launch resumes exactly where you left off. There is nothing to hand-edit; the picker (`^P` / `^/`) and `S-Tab` manage it. Compaction depth is set from the command palette's *Compaction depth* entry — see [Providers](/docs/providers#1m-context-models) for why you'd raise it on a 1M-context model.

--- a/include/agentty/provider/msg_shared.hpp
+++ b/include/agentty/provider/msg_shared.hpp
@@ -86,4 +86,41 @@ namespace agentty::provider::wire {
     return m;
 }
 
+// AGENTS.md — the open standard for project-scoped agent guidance, stewarded
+// by the Agentic AI Foundation (AAIF) under the Linux Foundation. See
+// https://agents.md. Unlike CLAUDE.md (a personal memory hierarchy with
+// user/project/local tiers), AGENTS.md is intentionally PROJECT-SCOPED ONLY
+// per the published spec: a single file at <project_root>/AGENTS.md, no
+// user tier, no local tier. (The spec also describes nested monorepo files
+// for subpackages; agentty's workspace model is single-tier, so we read
+// only the project-root file — the user explicitly chose this scope.)
+//
+// `project_root` is passed in (rather than resolved here) so this helper
+// stays self-contained: msg_shared.hpp does NOT pull in the util/fs_helpers
+// machinery, leaving the wire layer free of the ToolError/registry surface.
+// Callers (anthropic/prompt.cpp, openai/transport.cpp, ollama/transport.cpp)
+// already link util and resolve project_root() from there.
+//
+// Returns "" when the file is missing/empty so callers elide the block
+// without emitting an empty wrapper tag. Same 64 KiB cap + trailing-
+// whitespace trim as CLAUDE.md, via the shared wire::read_capped_file.
+//
+// Wire shape: a SEPARATE top-level <agents-md>…</agents-md> block, injected
+// BEFORE the existing <memory> block. Keeping the standardized public
+// project guidance visually distinct from personal CLAUDE.md notes lets the
+// model tell them apart and apply precedence correctly.
+[[nodiscard]] inline std::string agents_md_block(
+    std::string_view               intro,
+    const std::filesystem::path&   project_root) {
+    const std::string content = read_capped_file(project_root / "AGENTS.md");
+    if (content.empty()) return {};
+
+    std::string m = "\n\n<agents-md>\n";
+    m += intro;
+    m += "\n";
+    m += content;
+    m += "\n</agents-md>";
+    return m;
+}
+
 } // namespace agentty::provider::wire

--- a/src/provider/anthropic/prompt.cpp
+++ b/src/provider/anthropic/prompt.cpp
@@ -9,6 +9,7 @@
 #include "agentty/tool/memory_store.hpp"
 #include "agentty/tool/registry.hpp"
 #include "agentty/tool/skills.hpp"
+#include "agentty/tool/util/fs_helpers.hpp"   // util::project_root — AGENTS.md anchor
 #include "agentty/util/dbglog.hpp"
 
 #include <cstdlib>
@@ -157,6 +158,40 @@ namespace {
     emit_learned("user",    std::move(learned_user));
     emit_learned("project", std::move(learned_project));
     m << "</memory>";
+    return m.str();
+}
+
+// AGENTS.md — the open AAIF/Linux-Foundation standard for project-scoped
+// agent guidance (https://agents.md). Project-scoped only per the published
+// spec: a single file at <project_root>/AGENTS.md, no user tier, no local
+// tier. agentty's workspace model is single-tier (no per-subpackage nested
+// files), so this is the only AGENTS.md read.
+//
+// Reuses read_memory_cached despite the name — that function is a generic
+// mtime-cached file reader (cache key is the path string, so AGENTS.md
+// gets its own cache entry independent of the CLAUDE.md tiers). Same 64 KiB
+// cap, same process-lifetime cache, same concurrency contract.
+//
+// Wire shape: a SEPARATE top-level <agents-md>…</agents-md> block, injected
+// BEFORE the existing <memory> block. Standardized public project guidance
+// is visually distinct from personal CLAUDE.md notes so the model can
+// apply precedence correctly (AGENTS.md is the public spec; CLAUDE.md
+// tiers are personal/team memory). Sits behind the same Anthropic cache
+// breakpoint as collect_memory_blocks, so the wire cost is paid once per
+// ~5 min cache_control TTL window regardless.
+[[nodiscard]] std::string collect_agents_md_block() {
+    const std::string content =
+        read_memory_cached(tools::util::project_root() / "AGENTS.md");
+    if (content.empty()) return {};
+
+    std::ostringstream m;
+    m << "\n\n<agents-md>\n"
+      << "Project guidance following the open AGENTS.md standard "
+         "(agents.md, stewarded by the Agentic AI Foundation under the "
+         "Linux Foundation). Treat as authoritative public project "
+         "conventions.\n"
+      << content
+      << "\n</agents-md>";
     return m.str();
 }
 
@@ -407,6 +442,11 @@ std::string default_system_prompt(bool lean) {
         << "waste \xe2\x89\xa5" "10 minutes rediscovering this? If yes, store it; "
         << "if it's routine or speculative, don't. Never store secrets.\n"
         << "</memory-tools>\n";
+    // Append AGENTS.md (AAIF standard, project-scoped) BEFORE the CLAUDE.md
+    // tiers. Standardized public project guidance lands first, personal
+    // memory layers on top — same end-of-prompt position so the always-on
+    // rules above still anchor first.
+    oss << collect_agents_md_block();
     // Append CLAUDE.md tiers (User + Project + Local) when present.
     // Lives at the END of the prompt so the always-on rules above
     // anchor first; user-authored memory then layers on top.

--- a/src/provider/ollama/transport.cpp
+++ b/src/provider/ollama/transport.cpp
@@ -32,6 +32,7 @@
 #include "agentty/provider/wire.hpp"
 #include "agentty/provider/wire_supersede.hpp"
 #include "agentty/runtime/composer_attachment.hpp"
+#include "agentty/tool/util/fs_helpers.hpp"   // util::project_root — AGENTS.md anchor
 #include "agentty/util/base64.hpp"
 #include "agentty/util/dbglog.hpp"
 
@@ -1014,10 +1015,20 @@ void feed_ndjson(StreamCtx& ctx, const char* data, std::size_t len) {
 }
 
 // ── CLAUDE.md memory tiers (user-authored, concise) ─────────────────────────
+// AGENTS.md (AAIF standard, project-scoped) is prepended via
+// wire::agents_md_block so the standardized public project guidance appears
+// BEFORE the personal CLAUDE.md tiers — same ordering the Anthropic prompt
+// uses. Empty/missing AGENTS.md elides the block.
 std::string memory_blocks() {
-    return wire::claude_md_blocks(
-        "Project-specific guidance the user has authored. Treat these as "
-        "persistent context for THIS workspace and user.");
+    return wire::agents_md_block(
+               "Project guidance following the open AGENTS.md standard "
+               "(agents.md, stewarded by the Agentic AI Foundation under "
+               "the Linux Foundation). Treat as authoritative public "
+               "project conventions.",
+               tools::util::project_root())
+         + wire::claude_md_blocks(
+               "Project-specific guidance the user has authored. Treat these as "
+               "persistent context for THIS workspace and user.");
 }
 
 } // namespace

--- a/src/provider/openai/transport.cpp
+++ b/src/provider/openai/transport.cpp
@@ -42,6 +42,7 @@
 #include "agentty/provider/wire.hpp"
 #include "agentty/provider/wire_supersede.hpp"
 #include "agentty/runtime/composer_attachment.hpp"
+#include "agentty/tool/util/fs_helpers.hpp"   // util::project_root — AGENTS.md anchor
 #include "agentty/util/base64.hpp"
 #include "agentty/util/dbglog.hpp"
 
@@ -1601,11 +1602,20 @@ namespace {
 // prompts (a 14b answered "hi" with "I didn't understand" once the learned
 // facts were present). Local models get the concise user-authored CLAUDE.md
 // guidance and nothing else. The user/project/local wrapper is the shared
-// wire::claude_md_blocks (also used by the Ollama transport).
+// wire::claude_md_blocks (also used by the Ollama transport). AGENTS.md
+// (AAIF standard, project-scoped) is prepended via wire::agents_md_block
+// so the standardized public project guidance appears BEFORE the personal
+// CLAUDE.md tiers — same ordering the Anthropic prompt uses.
 [[nodiscard]] std::string local_memory_blocks() {
-    return wire::claude_md_blocks(
-        "Project-specific guidance the user has authored. Treat these as "
-        "persistent context for THIS workspace and user.");
+    return wire::agents_md_block(
+               "Project guidance following the open AGENTS.md standard "
+               "(agents.md, stewarded by the Agentic AI Foundation under "
+               "the Linux Foundation). Treat as authoritative public "
+               "project conventions.",
+               tools::util::project_root())
+         + wire::claude_md_blocks(
+               "Project-specific guidance the user has authored. Treat these as "
+               "persistent context for THIS workspace and user.");
 }
 
 } // namespace

--- a/tests/agents_md_test.cpp
+++ b/tests/agents_md_test.cpp
@@ -1,0 +1,142 @@
+// agents_md_test — locks the wire::agents_md_block helper that reads the
+// AAIF-stewarded AGENTS.md standard file (https://agents.md) and wraps it
+// in a dedicated <agents-md> system-prompt block, separate from the
+// existing CLAUDE.md <memory> block.
+//
+// Per the published spec, AGENTS.md is project-scoped only (no user tier,
+// no local tier, no nested monorepo walk inside agentty's single-tier
+// workspace model). The file lives at <project_root>/AGENTS.md and is
+// capped at 64 KiB by the shared wire::read_capped_file pipeline.
+//
+// Locks:
+//   • missing file → empty block (elided from the prompt)
+//   • present file → wrapped as <agents-md>…</agents-md> with intro line
+//   • >64 KiB body truncated to 64 KiB (same cap as CLAUDE.md)
+//   • path resolved from util::project_root(), not the raw process cwd,
+//     so --workspace overrides are honored
+
+#include <cstdio>
+#include <cstdlib>
+#include <filesystem>
+#include <fstream>
+#include <string>
+
+#include "agentty/provider/msg_shared.hpp"
+#include "agentty/tool/util/fs_helpers.hpp"
+
+namespace fs = std::filesystem;
+namespace wire = agentty::provider::wire;
+using agentty::tools::util::project_root;
+using agentty::tools::util::set_workspace_root;
+
+static int g_failures = 0;
+#define CHECK(cond)                                                          \
+    do {                                                                     \
+        if (!(cond)) {                                                       \
+            std::fprintf(stderr, "FAIL %s:%d: %s\n", __FILE__, __LINE__, #cond); \
+            ++g_failures;                                                    \
+        }                                                                    \
+    } while (0)
+
+static fs::path make_workspace() {
+    const fs::path tmp =
+        fs::temp_directory_path() / "agentty_agents_md_test_workspace";
+    fs::remove_all(tmp);
+    fs::create_directories(tmp);
+    return tmp;
+}
+
+static void write_file(const fs::path& p, std::string_view content) {
+    fs::create_directories(p.parent_path());
+    std::ofstream(p, std::ios::binary) << std::string(content);
+}
+
+static void test_missing_returns_empty() {
+    const auto ws = make_workspace();
+    set_workspace_root(ws);
+    fs::current_path(ws);
+    const std::string r = wire::agents_md_block("intro", project_root());
+    CHECK(r.empty());
+    fs::remove_all(ws);
+}
+
+static void test_wraps_content() {
+    const auto ws = make_workspace();
+    set_workspace_root(ws);
+    fs::current_path(ws);
+    write_file(ws / "AGENTS.md",
+               "## Build\n- cmake --build build\n## Tests\n- ctest\n");
+    const std::string r =
+        wire::agents_md_block("Standard project guidance.", project_root());
+    CHECK(!r.empty());
+    CHECK(r.find("<agents-md>") != std::string::npos);
+    CHECK(r.find("</agents-md>") != std::string::npos);
+    CHECK(r.find("Standard project guidance.") != std::string::npos);
+    CHECK(r.find("## Build") != std::string::npos);
+    CHECK(r.find("cmake --build build") != std::string::npos);
+    CHECK(r.find("## Tests") != std::string::npos);
+    CHECK(r.find("ctest") != std::string::npos);
+    fs::remove_all(ws);
+}
+
+static void test_truncates_at_cap() {
+    const auto ws = make_workspace();
+    set_workspace_root(ws);
+    fs::current_path(ws);
+    // 64 KiB + 1000 bytes — must be clipped to the 64 KiB cap that
+    // wire::read_capped_file enforces (same cap as CLAUDE.md).
+    std::string huge(64u * 1024u + 1000u, 'x');
+    write_file(ws / "AGENTS.md", huge);
+    // Use a unique intro marker so we can isolate the file-content portion
+    // (intro + content + closing tag together would otherwise inflate the
+    // measured size past the cap, masking whether the cap was applied).
+    // The helper inserts exactly one '\n' between intro and content, so an
+    // intro WITHOUT a trailing '\n' makes the offset arithmetic clean.
+    const std::string intro = "INTRO_MARKER_FOR_TRUNCATION";
+    const std::string r = wire::agents_md_block(intro, project_root());
+    const auto intro_pos = r.find(intro);
+    const auto close_pos = r.find("\n</agents-md>");
+    CHECK(intro_pos != std::string::npos);
+    CHECK(close_pos != std::string::npos);
+    // +1 to skip the single '\n' the helper inserts between intro and content.
+    const auto content_start = intro_pos + intro.size() + 1;
+    const auto body = r.substr(content_start, close_pos - content_start);
+    CHECK(body.size() <= 64u * 1024u);
+    fs::remove_all(ws);
+}
+
+static void test_uses_project_root_not_process_cwd() {
+    // Set workspace_root to ws, but chdir into an "other" dir that also
+    // has an AGENTS.md. project_root() returns the workspace root here
+    // (cwd outside the boundary falls back to the boundary per mcp-cpp's
+    // project_root contract), so the ws AGENTS.md is read and the "other"
+    // one is NOT.
+    const auto ws    = make_workspace();
+    const auto other = fs::temp_directory_path() / "agentty_agents_md_test_other";
+    fs::remove_all(other);
+    fs::create_directories(other);
+    set_workspace_root(ws);
+    write_file(ws / "AGENTS.md",    "workspace-root-AGENTS");
+    write_file(other / "AGENTS.md", "should-not-be-read");
+    // chdir OUTSIDE the workspace boundary so project_root() falls back to ws.
+    fs::current_path(other);
+    const std::string r = wire::agents_md_block("intro", project_root());
+    CHECK(r.find("workspace-root-AGENTS") != std::string::npos);
+    CHECK(r.find("should-not-be-read") == std::string::npos);
+    fs::current_path(fs::temp_directory_path());
+    fs::remove_all(ws);
+    fs::remove_all(other);
+}
+
+int main() {
+    test_missing_returns_empty();
+    test_wraps_content();
+    test_truncates_at_cap();
+    test_uses_project_root_not_process_cwd();
+    if (g_failures == 0) {
+        std::printf("agents_md_test: all checks passed\n");
+        return 0;
+    }
+    std::fprintf(stderr, "agents_md_test: %d check(s) failed\n", g_failures);
+    return 1;
+}


### PR DESCRIPTION
Read <project_root>/AGENTS.md per the open AGENTS.md spec stewarded by the Agentic AI Foundation under the Linux Foundation (agents.md). Project-scoped only — no user/local tier (the spec defines none) and no nested monorepo walk (agentty's workspace model is single-tier). Wrapped in a dedicated <agents-md> block and injected BEFORE the existing <memory> block so standardized public project guidance lands first, personal CLAUDE.md memory layers on top. Purely additive: missing file elides the block, so workspaces without AGENTS.md see no change.

- wire::agents_md_block(intro, project_root) in msg_shared.hpp: reads <project_root>/AGENTS.md via the shared 64 KiB read_capped_file pipeline; self-contained (no util/fs_helpers.hpp pull-in).
- collect_agents_md_block() in anthropic/prompt.cpp: mtime-cached via the existing read_memory_cached wrapper; injected before collect_memory_blocks() in default_system_prompt.
- openai/transport.cpp + ollama/transport.cpp: local_memory_blocks() / memory_blocks() now return agents_md_block + claude_md_blocks.
- tests/agents_md_test.cpp: missing-file elision, wrapping, 64 KiB cap, project_root() resolution (not raw process cwd).
- docs/website/configuration.md: AGENTS.md guidance section after CLAUDE.md guidance, with spec link.