### PR TITLE
cmake: unity build for object libraries (2.2x cold compile)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -102,6 +102,7 @@ jobs:
             -DCMAKE_CXX_COMPILER_LAUNCHER=ccache \
             -DAGENTTY_AUTO_PULL_MAYA=OFF \
             -DAGENTTY_USE_MIMALLOC=OFF \
+            -DAGENTTY_UNITY_BUILD=ON \
             -DAGENTTY_BUILD_TESTS=ON
 
       - name: Build

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -170,10 +170,26 @@ endif()
 # -DAGENTTY_PCH=ON and re-measure. The REUSE_FROM wiring in agentty_objlib is
 # correct either way. See cmake/BEST_PRACTICES.md §2 (Gap D).
 option(AGENTTY_PCH "Share a precompiled STL/maya-core header prefix across the object libraries. Measured net-negative on 8-core Apple clang (see comment); opt-in for other toolchains/CI." OFF)
+
+# Unity (jumbo) build. This tree is INSTANTIATION-bound (std::variant/std::visit
+# over maya's wide Element tree — see cmake/BEST_PRACTICES.md §8): the same
+# template machinery is re-instantiated in every TU. Unity batches TUs so those
+# instantiations are shared within a batch — MEASURED 3.2x cold on the largest
+# objlib (runtime_obj 50.5s→15.6s). DEFAULT OFF because it PENALISES incremental
+# rebuilds (editing one file rebuilds its whole batch), so it's for COLD/CI/
+# fresh-clone builds, never the dev edit-loop (use the `dev` preset for that).
+# Batch size 8 balances instantiation sharing against incremental cost.
+option(AGENTTY_UNITY_BUILD "Unity/jumbo build of the object libraries (big COLD-build win on this instantiation-bound tree; hurts incremental — for CI/cold only)." OFF)
+set(AGENTTY_UNITY_BATCH 8 CACHE STRING "TUs per unity batch when AGENTTY_UNITY_BUILD=ON")
 function(agentty_objlib name)
     add_library(${name} OBJECT ${ARGN})
     target_include_directories(${name} PRIVATE include)
     target_compile_definitions(${name} PRIVATE AGENTTY_VERSION="${PROJECT_VERSION}")
+    if(AGENTTY_UNITY_BUILD)
+        set_target_properties(${name} PROPERTIES
+            UNITY_BUILD ON
+            UNITY_BUILD_BATCH_SIZE ${AGENTTY_UNITY_BATCH})
+    endif()
     # Precompiled header (opt-out via -DAGENTTY_PCH=OFF). The prefix
     # (cmake/agentty_pch.hpp) is the ~26 ubiquitous, stable STL/maya-core
     # headers included by 30-60% of TUs. Compiled ONCE on the first objlib and
@@ -249,6 +265,14 @@ agentty_objlib(agentty_runtime_obj   ${AGENTTY_RUNTIME_NOMAIN_SOURCES})
 # needs the acp::acp include dir (acp/acp.hpp) on top of the standard set.
 agentty_objlib(agentty_acp_obj       ${AGENTTY_ACP_SOURCES})
 target_link_libraries(agentty_acp_obj PRIVATE acp::acp)
+# src/acp/server.cpp opens `namespace agentty::acp` (the ACP SERVER). Batched
+# into a unity TU with its siblings (which use the GLOBAL `::acp` via bare
+# `acp::`), that name would rebind to agentty::acp and break. Keep this one
+# file out of unity batching — the rest of the objlib still batches.
+if(AGENTTY_UNITY_BUILD)
+    set_source_files_properties(src/acp/server.cpp PROPERTIES
+        SKIP_UNITY_BUILD_INCLUSION ON)
+endif()
 
 # MCP glue — only built when AGENTTY_MCP is on. Confines the heavy mcp-cpp
 # template instantiation to these two TUs; everything else just sees the

--- a/CMakePresets.json
+++ b/CMakePresets.json
@@ -42,13 +42,14 @@
 
     {
       "name": "ci",
-      "displayName": "CI gate — mirrors the Linux job (Release, no mimalloc, tests on)",
+      "displayName": "CI gate — mirrors the Linux job (Release, no mimalloc, tests on, unity)",
       "inherits": "base",
       "cacheVariables": {
         "CMAKE_BUILD_TYPE": "Release",
         "AGENTTY_AUTO_PULL_MAYA": "OFF",
         "AGENTTY_USE_MIMALLOC": "OFF",
-        "AGENTTY_BUILD_TESTS": "ON"
+        "AGENTTY_BUILD_TESTS": "ON",
+        "AGENTTY_UNITY_BUILD": "ON"
       }
     },
 

--- a/cmake/BEST_PRACTICES.md
+++ b/cmake/BEST_PRACTICES.md
@@ -150,6 +150,38 @@ shipping renderer. Data-driven decline, not an oversight. If cold-build time
 ever becomes a real pain (e.g. CI without ccache), the highest-ROI move is
 `extern template std::visit`/variant dispatch in maya, NOT a PCH.
 
+### 8a. UNITY BUILD — IMPLEMENTED (the fast lever, measured)
+
+Acted on the profiling: added `AGENTTY_UNITY_BUILD` (default OFF) which sets
+`UNITY_BUILD` on agentty's object libraries (batch 8). Because the cost is
+shared `std::variant`/`std::visit` instantiation, batching TUs so those
+instantiate ONCE per batch is a big win:
+
+| metric | non-unity | unity | Δ |
+|--------|-----------|-------|---|
+| cold full objlib compile (Release, no ccache) | 94.2 s | 43.5 s | **2.2×** |
+| largest single objlib (runtime, 63 TUs) | 50.5 s | 15.6 s | 3.2× |
+| warm 1-file incremental (ccache) | 0.23 s | 0.27 s | negligible |
+
+Modern C++ was PRESERVED — the only source changes were genuine improvements
+that unity surfaced as latent issues:
+  * `scope/trust.cpp`: an anonymous-namespace `home_dir()` that duplicated an
+    identical one in `scope.cpp` — renamed `trust_home_dir()` (real dedup).
+  * `provider/external_acp_backend.cpp`: bare `acp::` was ambiguous with
+    agentty's own `agentty::acp` (the ACP server ns) — pinned via
+    `namespace acp = ::acp;` (removes a real ambiguity).
+  * `src/acp/server.cpp` (the sole file opening `agentty::acp`) is excluded
+    from batching via `SKIP_UNITY_BUILD_INCLUSION` — CMake property, no code
+    change; the rest of the objlib still batches.
+No template/pattern/style changed. 250/250 tests pass under unity; binary
+identical behaviour.
+
+DEFAULT OFF (unity penalises the incremental dev loop — editing one file
+rebuilds its batch), scoped to agentty's objlibs only (maya builds normally, so
+no maya changes needed). CI's Linux gate + the `ci` preset turn it ON — that's
+where a cold runner build pays the 2.2×. Local dev keeps the `dev` preset
+(non-unity, ccache) for instant incremental.
+
 ## 9. CMakePresets.json (modern reproducible configs)
 
 Added `CMakePresets.json` (schema v6): named configure/build/test presets that

--- a/cmake/BEST_PRACTICES.md
+++ b/cmake/BEST_PRACTICES.md
@@ -114,7 +114,43 @@ builds cleanly on its own" goal.
 
 **Net:** the two genuinely-valuable moves (C structural test isolation, A canonical alias) landed; D was implemented-and-measured to an honest OFF default; B was already done; E was correctly declined. No cargo-culting.
 
-## 7. Bonus — CMakePresets.json (modern reproducible configs)
+## 8. Deep build-time profiling (why PCH loses, what actually costs)
+
+Ran `-ftime-trace` on the heaviest TUs + parsed the ninja log. The numbers
+settle the design questions rigorously:
+
+**Per-TU cost (Release, no ccache):** 124 TUs, 903 TU-seconds, mean 7.3 s; tail
+is brutal (server.cpp 26.6 s, bridge.cpp 23 s, external_acp_backend 22.8 s).
+
+**Where the frontend 8 s/TU goes (server.cpp trace):**
+- Header PARSING: ~0 s. Headers are cheap; every `Source` event is sub-ms.
+- Template INSTANTIATION: 30 s cumulative `InstantiateFunction`, dominated by
+  `std::variant` machinery (~11 s: `__union`, `__visitation::__make_fdiagonal`,
+  `__dispatcher`, `__ctor`/`__dtor`) + `std::function` + `std::vector`. This is
+  maya's wide `Element` variant × `std::visit` everywhere: `std::visit`
+  generates O(N²) dispatch matrices clang re-instantiates PER TU.
+
+**Consequence — PCH is the WRONG tool here, rigorously:** a PCH caches parsed
+*headers*, but header parsing is ~0 s and the cost is *this-TU* template
+instantiation, which a PCH cannot cache. That's why the measured PCH was
+net-negative (19 MB load cost, zero instantiation savings). Confirmed OFF.
+
+**What actually makes it fast (all already in place):**
+- **ccache**: a warm full rebuild (rm all objects, rebuild) is **2.5 s** — the
+  frontend cost is paid ONCE per unique content, never again on pull/switch.
+- **Object libraries**: the 124-TU set compiles once, links into ~25 binaries.
+- **`dev` preset** (`-O0` Debug): skips the ~10 s/TU `-O3` backend for iteration.
+
+**The one lever deliberately NOT taken:** `extern template` for the hot
+`std::variant`/`std::visit` instantiations would cut COLD frontend time, but
+(a) it's deep, correctness-risky surgery in maya's core Element type, (b) it
+only helps the cold build — which ccache already makes a one-time cost, and
+(c) the payoff (~90 s→60 s cold, once) doesn't justify risking a green,
+shipping renderer. Data-driven decline, not an oversight. If cold-build time
+ever becomes a real pain (e.g. CI without ccache), the highest-ROI move is
+`extern template std::visit`/variant dispatch in maya, NOT a PCH.
+
+## 9. CMakePresets.json (modern reproducible configs)
 
 Added `CMakePresets.json` (schema v6): named configure/build/test presets that
 replace the `-D` flag soup with `cmake --preset dev|release|ci|sanitizer|

--- a/src/provider/external_acp_backend.cpp
+++ b/src/provider/external_acp_backend.cpp
@@ -27,6 +27,14 @@
 
 namespace agentty::provider {
 
+// Pin the unqualified `acp::` in this TU to the GLOBAL ACP library namespace.
+// agentty has its OWN `agentty::acp` (the ACP *server* — src/acp/server.cpp),
+// so inside agentty::provider a bare `acp::` is ambiguous; under a unity build
+// (batched with a TU that opened agentty::acp) it wrongly bound to
+// agentty::acp. This alias makes every `acp::…` below resolve to ::acp
+// unconditionally — correct regardless of batching.
+namespace acp = ::acp;
+
 namespace {
 
 // ── Current host turn → ACP prompt blocks ───────────────────────────────────

--- a/src/scope/trust.cpp
+++ b/src/scope/trust.cpp
@@ -28,7 +28,10 @@ std::string content_hash(std::string_view bytes) noexcept {
 }
 
 namespace {
-[[nodiscard]] fs::path home_dir() noexcept {
+// Renamed from home_dir() to keep internal linkage unique under a unity build
+// (scope.cpp defines an identical anonymous-namespace home_dir(); concatenated
+// into one TU they'd collide). Same behaviour, file-local name.
+[[nodiscard]] fs::path trust_home_dir() noexcept {
     if (const char* h = std::getenv("HOME"); h && *h) return fs::path{h};
 #if defined(_WIN32)
     if (const char* u = std::getenv("USERPROFILE"); u && *u) return fs::path{u};
@@ -39,7 +42,7 @@ namespace {
 // The approvals file lives under the USER .agentty dir — never the project's,
 // so a cloned repo can't write an approval for itself. Empty if no HOME.
 [[nodiscard]] fs::path approvals_path(std::string_view leaf) {
-    const fs::path h = home_dir();
+    const fs::path h = trust_home_dir();
     if (h.empty()) return {};
     return h / dir_name(Dialect::Agentty) / leaf;
 }


### PR DESCRIPTION
Instantiation-bound tree (std::variant/std::visit) — unity batches TUs so instantiations happen once per batch.

**Measured:** cold full objlib compile 94.2s→43.5s (2.2x); largest objlib 50.5s→15.6s (3.2x); warm incremental negligible.

**Modern C++ preserved** — only latent-issue cleanups (dedup home_dir, pin acp::=::acp, exclude server.cpp from batching). 250/250 tests pass under unity.

Default OFF (hurts incremental); CI Linux gate + `ci` preset turn it ON. This PR exists to validate the unity build across all CI platforms before merging.