### PR TITLE
tests: fold 17 standalone binaries into one argv-dispatched exe (27→6)

### DIFF
--- a/cmake/AgenttyTestRegistry.cmake
+++ b/cmake/AgenttyTestRegistry.cmake
@@ -169,6 +169,70 @@ function(agentty_mark_sanitizer)
     endforeach()
 endfunction()
 
+# ── The folded standalone-test binary ───────────────────────────────────────
+# agentty_standalone_tests: ONE exe holding the full-stack standalone tests
+# (forkers / PTY / fuzzers / e2e / benches) that can't be doctest cases in a
+# shared process. Each is still run in its OWN process per ctest entry via
+# argv dispatch (agentty_standalone_tests <name> [args]) — so fork/PTY/chdir
+# isolation is preserved — but ~16 heavy 100 MB+ links collapse into one.
+#
+#   agentty_fold_test(<name> [TIMEOUT n] [LABELS ..] [ARGS] [UNIX_LIBS ..])
+# records the test; agentty_finalize_fold() builds the single binary + the
+# per-test ctest entries. Extra link libs/objs the fold needs (mcp::mcp,
+# acp::acp, agentty_acp_obj) are added once on the binary in AgenttyTests.cmake.
+define_property(DIRECTORY PROPERTY AGENTTY_FOLD_NAMES
+    BRIEF_DOCS "folded standalone test names" FULL_DOCS "AgenttyTestRegistry")
+
+function(agentty_fold_test name)
+    cmake_parse_arguments(F "ARGS" "TIMEOUT" "LABELS;UNIX_LIBS" ${ARGN})
+    set_property(DIRECTORY APPEND PROPERTY AGENTTY_FOLD_NAMES ${name})
+    # Rename this TU's main() to <name>_main so the dispatcher can call it.
+    set_source_files_properties(${CMAKE_SOURCE_DIR}/tests/${name}.cpp
+        PROPERTIES COMPILE_DEFINITIONS "main=${name}_main")
+    if(F_UNIX_LIBS)
+        set_property(DIRECTORY APPEND PROPERTY AGENTTY_FOLD_UNIX_LIBS ${F_UNIX_LIBS})
+    endif()
+    # ctest entry: run this test as its own process via the shared binary.
+    if(NOT F_TIMEOUT)
+        set(F_TIMEOUT 60)
+    endif()
+    add_test(NAME ${name} COMMAND agentty_standalone_tests ${name})
+    set_tests_properties(${name} PROPERTIES TIMEOUT ${F_TIMEOUT})
+    if(F_LABELS)
+        set_tests_properties(${name} PROPERTIES LABELS "${F_LABELS}")
+        if("perf" IN_LIST F_LABELS)
+            set_property(DIRECTORY APPEND PROPERTY AGENTTY_T_PERF ${name})
+        endif()
+    endif()
+endfunction()
+
+# Build the one binary from all recorded fold TUs + the dispatcher. Extra
+# libs/objs are passed by the caller (union of every folded test's needs).
+function(agentty_finalize_fold)
+    cmake_parse_arguments(FF "" "" "OBJS;LIBS" ${ARGN})
+    get_property(_names DIRECTORY PROPERTY AGENTTY_FOLD_NAMES)
+    set(_srcs ${CMAKE_SOURCE_DIR}/tests/agentty_standalone_tests_main.cpp)
+    foreach(_n ${_names})
+        list(APPEND _srcs ${CMAKE_SOURCE_DIR}/tests/${_n}.cpp)
+    endforeach()
+    add_executable(agentty_standalone_tests EXCLUDE_FROM_ALL
+        ${_srcs} ${AGENTTY_SHARED_OBJECTS} ${FF_OBJS})
+    _agentty_test_link_full(agentty_standalone_tests)
+    target_link_libraries(agentty_standalone_tests PRIVATE ${FF_LIBS})
+    get_property(_ulibs DIRECTORY PROPERTY AGENTTY_FOLD_UNIX_LIBS)
+    if(_ulibs AND UNIX AND NOT APPLE)
+        target_link_libraries(agentty_standalone_tests PRIVATE ${_ulibs})
+    endif()
+    # Test binaries never ship — no LTO (faster + dodges the GCC init-order
+    # hazard, same rationale as agentty_tests).
+    set_target_properties(agentty_standalone_tests PROPERTIES
+        INTERPROCEDURAL_OPTIMIZATION OFF)
+    # The dispatcher #includes tests/agentty_standalone_tests.def.
+    target_include_directories(agentty_standalone_tests PRIVATE ${CMAKE_SOURCE_DIR}/tests)
+    # It counts as one entry in the standalone aggregate.
+    set_property(DIRECTORY APPEND PROPERTY AGENTTY_T_STANDALONE agentty_standalone_tests)
+endfunction()
+
 function(agentty_finalize_tests)
     get_property(_srcs DIRECTORY PROPERTY AGENTTY_T_CONSOLIDATED_SRCS)
     add_executable(agentty_tests EXCLUDE_FROM_ALL

--- a/cmake/AgenttyTests.cmake
+++ b/cmake/AgenttyTests.cmake
@@ -38,46 +38,51 @@ endforeach()
 
 # ── Standalone full-stack tests ─────────────────────────────────────────────
 # Forkers / PTY / fuzzers / e2e / benches that can't share the doctest process.
-agentty_test(long_session_bench      MODE standalone TIMEOUT 600 LABELS perf)
-agentty_test(cross_process_lock_test MODE standalone TIMEOUT 30)
-agentty_test(fork_test               MODE standalone TIMEOUT 30)
-agentty_test(reveal_freeze_gate_probe MODE standalone TIMEOUT 30)
-agentty_test(toolset_e2e_test        MODE standalone TIMEOUT 120)
-agentty_test(subagent_report_test    MODE standalone TIMEOUT 60)
-# agents_md_test — locks wire::agents_md_block (AAIF AGENTS.md standard,
-# project-scoped). Standalone (own main(), touches fs:: for temp workspaces)
-# rather than consolidated; not sanitizer-labelled because it links the
-# shared object set that pulls maya::maya (ODR-clashes under asan).
+# ── Folded standalone tests ────────────────────────────────────────────
+# These can't be doctest cases in a shared process (fork/exec, PTY, fuzz seed
+# loops, subprocess e2e) — but they DON'T each need their own 100 MB+ link.
+# agentty_fold_test() puts them all in ONE binary (agentty_standalone_tests)
+# and gives each its own ctest entry that runs it as a separate PROCESS:
+#   add_test(NAME x COMMAND agentty_standalone_tests x)
+# so process isolation is identical to before, at 1 link instead of ~16.
+# Each TU's main() is renamed to <name>_main via a per-source -Dmain=; the
+# dispatcher (tests/agentty_standalone_tests_main.cpp + .def) calls it.
+agentty_fold_test(long_session_bench       TIMEOUT 600 LABELS perf)
+agentty_fold_test(cross_process_lock_test  TIMEOUT 30)
+agentty_fold_test(fork_test                TIMEOUT 30)
+agentty_fold_test(reveal_freeze_gate_probe TIMEOUT 30)
+agentty_fold_test(toolset_e2e_test         TIMEOUT 120)
+agentty_fold_test(subagent_report_test     TIMEOUT 60)
+agentty_fold_test(plugin_disabled_tools_test TIMEOUT 60)
+agentty_fold_test(frozen_invariant_fuzz)
+agentty_fold_test(scrollback_wire_fuzz     TIMEOUT 120)
+agentty_fold_test(reveal_scrollback_test   TIMEOUT 180 UNIX_LIBS util)
+agentty_fold_test(scrollback_oracle_test   TIMEOUT 600 UNIX_LIBS util)
+agentty_fold_test(external_acp_backend_test TIMEOUT 60)
+agentty_fold_test(md_shape_sweep           TIMEOUT 120)
+agentty_fold_test(md_cache_probe           TIMEOUT 120)
+if(AGENTTY_MCP)
+    agentty_fold_test(mcp_bridge_test      TIMEOUT 60)
+    set_tests_properties(mcp_bridge_test PROPERTIES ENVIRONMENT
+        "AGENTTY_MCP_E2E_SERVER=${CMAKE_BINARY_DIR}/mcp-cpp/examples/mcp_server_example")
+    agentty_fold_test(mcp_http_test        TIMEOUT 60)
+endif()
+# anthropic_md_stream is a capture/replay HARNESS, not a ctest entry of its own:
+# the reveal_stream_gate* arms below invoke it (with args) through the folded
+# binary. Registered in the .def; no add_test here.
+set_source_files_properties(${CMAKE_SOURCE_DIR}/tests/anthropic_md_stream.cpp
+    PROPERTIES COMPILE_DEFINITIONS "main=anthropic_md_stream_main")
+set_property(DIRECTORY APPEND PROPERTY AGENTTY_FOLD_NAMES anthropic_md_stream)
+
+# Build the one binary: union of every folded test's extra objs/libs.
+agentty_finalize_fold(
+    OBJS $<TARGET_OBJECTS:agentty_acp_obj>
+    LIBS acp::acp)
+
+# agents_md_test — locks wire::agents_md_block (AAIF AGENTS.md standard).
+# Kept as its OWN binary: it chdir()s into temp workspaces, and it's new enough
+# that folding it hasn't been validated.
 agentty_test(agents_md_test          MODE standalone TIMEOUT 30)
-agentty_test(plugin_disabled_tools_test MODE standalone TIMEOUT 60)
-agentty_test(frozen_invariant_fuzz   MODE standalone)
-agentty_test(scrollback_wire_fuzz    MODE standalone TIMEOUT 120)
-agentty_test(reveal_scrollback_test  MODE standalone TIMEOUT 180 UNIX_LIBS util)
-agentty_test(scrollback_oracle_test  MODE standalone TIMEOUT 600 UNIX_LIBS util)
-
-# ACP tests need the acp glue objects + acp::acp on top of the shared stack.
-agentty_test(external_acp_backend_test MODE standalone TIMEOUT 60
-    OBJS $<TARGET_OBJECTS:agentty_acp_obj> LIBS acp::acp)
-
-# MCP e2e — only when MCP is compiled in.
-agentty_test(mcp_bridge_test MODE standalone TIMEOUT 60 GATE AGENTTY_MCP LIBS mcp::mcp
-    ENV "AGENTTY_MCP_E2E_SERVER=${CMAKE_BINARY_DIR}/mcp-cpp/examples/mcp_server_example")
-agentty_test(mcp_http_test   MODE standalone TIMEOUT 60 GATE AGENTTY_MCP LIBS mcp::mcp)
-
-# ── Dev probes / capture tools (built, NOT ctest entries) ───────────────────
-# maya-linked probes: just maya::maya, no agentty sources.
-foreach(_p md_shape_sweep md_cache_probe)
-    agentty_test(${_p} MODE raw)
-    add_executable(${_p} EXCLUDE_FROM_ALL tests/${_p}.cpp)
-    target_link_libraries(${_p} PRIVATE maya::maya)
-    add_test(NAME ${_p} COMMAND ${_p})
-    set_tests_properties(${_p} PROPERTIES TIMEOUT 120)
-endforeach()
-
-# anthropic_md_stream is a capture/replay HARNESS, not a perf probe: the
-# reveal_stream_gate* CORRECTNESS ctest entries run it. Keep it OUT of the perf
-# label so tests_gating still builds it (otherwise those gates are "Not Run").
-agentty_test(anthropic_md_stream    MODE standalone NO_TEST)
 
 # ── Narrow-source sanitizer tests (raw: must NOT link the full shared set) ──
 # They exercise agentty's own logic and link cleanly under asan/ubsan without
@@ -120,13 +125,13 @@ agentty_finalize_tests()
 # Regression gate on the live reveal glide over a recorded Anthropic stream.
 set(_RSG_FIXTURE ${CMAKE_SOURCE_DIR}/tests/fixtures/anthropic_md_smoke.jsonl)
 agentty_add_ctest(reveal_stream_gate COMMAND
-    anthropic_md_stream det ${_RSG_FIXTURE}
+    agentty_standalone_tests anthropic_md_stream det ${_RSG_FIXTURE}
     --assert-max-delta 40 --assert-finalize-max 40 --assert-finalize-ms 3600)
 agentty_add_ctest(reveal_stream_gate_prod COMMAND
-    anthropic_md_stream det ${_RSG_FIXTURE}
+    agentty_standalone_tests anthropic_md_stream det ${_RSG_FIXTURE}
     --cps 45 --drain 0.40 --adaptive
     --assert-max-delta 40 --assert-finalize-max 40 --assert-finalize-ms 3600)
 agentty_add_ctest(reveal_stream_gate_snap COMMAND
-    anthropic_md_stream det ${_RSG_FIXTURE}
+    agentty_standalone_tests anthropic_md_stream det ${_RSG_FIXTURE}
     --cps 45 --drain 0.40 --adaptive --snap-at 40 --snap-glide 150
     --assert-max-delta 40 --assert-finalize-max 40 --assert-finalize-ms 3600)

--- a/tests/agentty_standalone_tests.def
+++ b/tests/agentty_standalone_tests.def
@@ -1,0 +1,25 @@
+// agentty_standalone_tests.def — the fold set + each test's original main()
+// arity. Included multiple times by agentty_standalone_tests_main.cpp with
+// FOLD_NOARGS / FOLD_ARGS redefined (X-macro). Keep in sync with the
+// agentty_standalone_tests source list in cmake/AgenttyTests.cmake.
+//
+// NOARGS = original was `int main()`.   ARGS = `int main(int, char**)`.
+
+FOLD_NOARGS(fork_test)
+FOLD_NOARGS(cross_process_lock_test)
+FOLD_NOARGS(reveal_freeze_gate_probe)
+FOLD_NOARGS(toolset_e2e_test)
+FOLD_NOARGS(subagent_report_test)
+FOLD_NOARGS(plugin_disabled_tools_test)
+FOLD_NOARGS(frozen_invariant_fuzz)
+FOLD_NOARGS(scrollback_wire_fuzz)
+FOLD_NOARGS(reveal_scrollback_test)
+FOLD_NOARGS(scrollback_oracle_test)
+FOLD_NOARGS(mcp_bridge_test)
+FOLD_NOARGS(mcp_http_test)
+FOLD_NOARGS(md_shape_sweep)
+
+FOLD_ARGS(external_acp_backend_test)
+FOLD_ARGS(long_session_bench)
+FOLD_ARGS(anthropic_md_stream)
+FOLD_ARGS(md_cache_probe)

--- a/tests/agentty_standalone_tests_main.cpp
+++ b/tests/agentty_standalone_tests_main.cpp
@@ -1,0 +1,58 @@
+// agentty_standalone_tests — one binary, argv-dispatched, for the full-stack
+// standalone tests that CANNOT be doctest cases in a shared process (they
+// fork/exec, drive a PTY, run fuzz seed loops, or spawn subprocesses). Each is
+// still run in its OWN process per ctest entry:  agentty_standalone_tests <name>
+// [args…] → the test's original main.  Folds ~16 heavy 100 MB+ links into one.
+//
+// Each test's `int main(...)` is renamed to `<name>_main` at compile time via a
+// per-source `-Dmain=<name>_main` (see cmake/AgenttyTests.cmake). A test's
+// ORIGINAL signature is preserved by the rename, so the .def below records each
+// test's arity: NOARGS (int main()) vs ARGS (int main(int,char**)).  For an ARGS
+// test we pass argv[1..] through so it parses its own flags (anthropic_md_stream:
+// `det <fixture> --cps …`).
+//
+// The 3 sanitizer-narrow tests (concurrency_primitives / cred_crypt / keystore)
+// are NOT here — they link a deliberately minimal source subset to stay
+// asan-clean, which folding into the full object set would defeat.
+#include <cstdio>
+#include <string_view>
+
+// Declarations — arity per the original main().
+#define FOLD_NOARGS(name) extern int name##_main();
+#define FOLD_ARGS(name)   extern int name##_main(int, char**);
+#include "agentty_standalone_tests.def"
+#undef FOLD_NOARGS
+#undef FOLD_ARGS
+
+int main(int argc, char** argv) {
+    if (argc < 2) {
+        std::fprintf(stderr,
+            "usage: %s <test-name> [args…]\n\nAvailable tests:\n", argv[0]);
+#define FOLD_NOARGS(name) std::fprintf(stderr, "  %s\n", #name);
+#define FOLD_ARGS(name)   std::fprintf(stderr, "  %s\n", #name);
+#include "agentty_standalone_tests.def"
+#undef FOLD_NOARGS
+#undef FOLD_ARGS
+        return 2;
+    }
+    const std::string_view which{argv[1]};
+    // Build the sub-argv: keep argv[0] as the REAL executable path (a test may
+    // re-exec itself — external_acp_backend_test spawns argv[0] as a fake ACP
+    // agent), drop the dispatch name at argv[1], keep the rest as the test's
+    // own flags. So `agentty_standalone_tests anthropic_md_stream det X --cps 45`
+    // reaches the test as argv = {<exe-path>, "det", "X", "--cps", "45"}.
+    int    sub_argc = argc - 1;
+    char** sub_argv = argv + 1;
+    sub_argv[0] = argv[0];   // real exe path, not the test name
+
+#define FOLD_NOARGS(name) if (which == #name) return name##_main();
+#define FOLD_ARGS(name)   if (which == #name) return name##_main(sub_argc, sub_argv);
+#include "agentty_standalone_tests.def"
+#undef FOLD_NOARGS
+#undef FOLD_ARGS
+
+    std::fprintf(stderr, "%s: unknown test '%.*s'\n",
+                 argv[0], static_cast<int>(which.size()), which.data());
+    (void)sub_argc; (void)sub_argv;
+    return 2;
+}

--- a/tests/cross_process_lock_test.cpp
+++ b/tests/cross_process_lock_test.cpp
@@ -29,12 +29,15 @@ namespace fs = std::filesystem;
 using agentty::auth::CrossProcessFileLock;
 using clock_t_ = std::chrono::steady_clock;
 
+namespace {  // fold: TU-local (bundled into agentty_standalone_tests)
 static int g_fail = 0;
 #define CHECK(cond, msg)                                                       \
     do {                                                                       \
         if (!(cond)) { std::printf("  FAIL: %s\n", msg); ++g_fail; }           \
         else         { std::printf("  ok:   %s\n", msg); }                     \
     } while (0)
+
+}  // namespace (fold)
 
 int main() {
     std::printf("[cross_process_lock]\n");

--- a/tests/external_acp_backend_test.cpp
+++ b/tests/external_acp_backend_test.cpp
@@ -593,7 +593,11 @@ void test_spawn_real_subprocess(const std::string& self_path) {
 
     InitializeParams init;
     std::string err;
-    auto agent = P::spawn_acp_agent({self_path, "--acp-agent"}, init,
+    auto agent = P::spawn_acp_agent(
+        // Bundled into agentty_standalone_tests (argv-dispatched), so the child
+        // must carry the dispatch name before its own child-mode flag:
+        //   <exe> external_acp_backend_test --acp-agent
+        {self_path, "external_acp_backend_test", "--acp-agent"}, init,
                                     backend->make_handlers(), err);
     if (!agent.ok()) {
         std::cerr << "spawn_acp_agent failed: " << err << "\n";
@@ -622,7 +626,8 @@ void test_wedged_child_teardown_is_bounded(const std::string& self_path) {
     P::TurnSink sink; sink.update = [](acp::SessionUpdate){};
     InitializeParams init;
     std::string err;
-    auto agent = P::spawn_acp_agent({self_path, "--acp-agent-wedged"}, init,
+    auto agent = P::spawn_acp_agent(
+        {self_path, "external_acp_backend_test", "--acp-agent-wedged"}, init,
                                     backend->make_handlers(), err);
     if (!agent.ok()) {
         std::cerr << "spawn wedged agent failed: " << err << "\n";

--- a/tests/frozen_invariant_fuzz.cpp
+++ b/tests/frozen_invariant_fuzz.cpp
@@ -68,6 +68,7 @@ using agentty::ToolUse;
 using std::chrono::milliseconds;
 using std::chrono::steady_clock;
 
+namespace {  // fold: TU-local (bundled into agentty_standalone_tests)
 static int g_failures = 0;
 static int g_checks   = 0;
 
@@ -409,6 +410,8 @@ static void run_walk(std::uint64_t seed, int width) {
         if (g_failures) return;  // stop on first failure for a clean trace
     }
 }
+
+}  // namespace (fold)
 
 int main() {
     std::printf("frozen_invariant_fuzz\n");

--- a/tests/long_session_bench.cpp
+++ b/tests/long_session_bench.cpp
@@ -286,6 +286,10 @@ int s_id_counter = 0;
 // Scenario shape — declarative parametrisation
 // ─────────────────────────────────────────────────────────────────────────
 
+// Anonymous namespace: bundled into agentty_standalone_tests, where
+// md_shape_sweep declares its own `Shape` — internal linkage keeps the two
+// TU-local types from colliding (ODR).
+namespace {
 struct Shape {
     std::string name;
     int  n_turns           = 0;     // assistant turns; user turn paired with each
@@ -300,6 +304,7 @@ struct Shape {
     int  user_text_chars   = 80;    // user message length per turn
     int  iters             = 5;     // outer-loop iterations for stats
 };
+}  // namespace (fold: Shape is TU-local)
 
 [[nodiscard]] std::string user_prompt(int chars) {
     std::string s;

--- a/tests/mcp_bridge_test.cpp
+++ b/tests/mcp_bridge_test.cpp
@@ -20,6 +20,7 @@
 namespace fs = std::filesystem;
 using namespace agentty;
 
+namespace {  // fold: TU-local (bundled into agentty_standalone_tests)
 static int g_failures = 0;
 #define CHECK(cond)                                                            \
     do {                                                                       \
@@ -45,6 +46,8 @@ static std::string find_server() {
         if (fs::is_regular_file(c, ec)) return fs::absolute(c, ec).string();
     return {};
 }
+
+}  // namespace (fold)
 
 int main() {
     // ── Robustness: a server whose command does NOT exist must be SKIPPED

--- a/tests/md_cache_probe.cpp
+++ b/tests/md_cache_probe.cpp
@@ -22,6 +22,7 @@
 using namespace maya;
 using clk = std::chrono::steady_clock;
 
+namespace {  // fold: TU-local (bundled into agentty_standalone_tests)
 static constexpr int kWidth = 100;
 static constexpr int kTermH = 40;
 
@@ -78,6 +79,8 @@ static std::vector<ShapeGen> shapes() {
     }
     return v;
 }
+
+}  // namespace (fold)
 
 int main(int argc, char** argv) {
     const char* only = argc > 1 ? argv[1] : nullptr;

--- a/tests/md_shape_sweep.cpp
+++ b/tests/md_shape_sweep.cpp
@@ -18,6 +18,7 @@
 
 using namespace maya;
 
+namespace {  // fold: TU-local (bundled into agentty_standalone_tests)
 static constexpr int kWidth = 80;
 static constexpr int kTermH = 40;
 
@@ -93,6 +94,8 @@ static std::vector<Shape> corpus() {
 }
 
 static int rows_of(const Canvas& c) { return c.max_content_row() + 1; }
+
+}  // namespace (fold)
 
 int main() {
     StylePool pool_dummy;

--- a/tests/plugin_disabled_tools_test.cpp
+++ b/tests/plugin_disabled_tools_test.cpp
@@ -26,6 +26,7 @@
 namespace fs = std::filesystem;
 using namespace agentty;
 
+namespace {  // fold: TU-local (bundled into agentty_standalone_tests)
 static int g_fails = 0;
 static void check(bool ok, const std::string& what) {
     std::printf("  [%s] %s\n", ok ? "PASS" : "FAIL", what.c_str());
@@ -38,6 +39,8 @@ static std::size_t tool_count_for(const std::string& server) {
         if (s.name == server) return s.tools.size();
     return static_cast<std::size_t>(-1);   // server absent
 }
+
+}  // namespace (fold)
 
 int main() {
     std::signal(SIGPIPE, SIG_IGN);

--- a/tests/reveal_freeze_gate_probe.cpp
+++ b/tests/reveal_freeze_gate_probe.cpp
@@ -55,6 +55,7 @@ using agentty::Message;
 using agentty::Role;
 using agentty::app::AgenttyApp;
 
+namespace {  // fold: TU-local (bundled into agentty_standalone_tests)
 static int g_checks = 0, g_failures = 0;
 #define CHECK(cond, msg)                                                    \
     do {                                                                    \
@@ -242,6 +243,8 @@ static void test_settled_turn_is_hash_stable() {
           "settled idle turn — the fast reveal bucket is leaking and the "
           "loop will burn CPU at idle");
 }
+
+}  // namespace (fold)
 
 int main() {
     // Pin the sync-output classification so the reveal render bucket is the

--- a/tests/reveal_scrollback_test.cpp
+++ b/tests/reveal_scrollback_test.cpp
@@ -79,6 +79,7 @@ using agentty::ToolUse;
 using namespace maya;
 using namespace maya::inline_frame;
 
+namespace {  // fold: TU-local (bundled into agentty_standalone_tests)
 static int g_failures = 0;
 static int g_checks   = 0;
 
@@ -1421,6 +1422,8 @@ static void run_trimstorm_scenario(int width, int term_h) {
     }
     if (pty_master >= 0) close(pty_master);
 }
+
+}  // namespace (fold)
 
 int main() {
     // Each scenario dup2's a PTY over STDOUT to give term_dims() real

--- a/tests/scrollback_oracle_test.cpp
+++ b/tests/scrollback_oracle_test.cpp
@@ -51,6 +51,8 @@ using agentty::Message;
 using agentty::Role;
 using agentty::ToolUse;
 
+namespace {  // fold: TU-local (bundled into agentty_standalone_tests)
+
 static FILE* err = nullptr;
 static int g_failures = 0;
 // Ground-truth count of times maya's scrollback gate had to RECOVER
@@ -1244,6 +1246,8 @@ done:
     close(master);
     return 0;
 }
+
+}  // namespace (fold)
 
 int main() {
     // Debug-built libmaya ABORTS on any scrollback-gate firing (the loud

--- a/tests/scrollback_wire_fuzz.cpp
+++ b/tests/scrollback_wire_fuzz.cpp
@@ -59,6 +59,7 @@ using std::chrono::steady_clock;
 // to a constant instant (12:00 UTC — with TZ=UTC set in run_walk) so the
 // rendered header bytes are identical on every machine and a committed row's
 // content stays a pure function of model state.
+namespace {  // fold: TU-local (bundled into agentty_standalone_tests)
 static const std::chrono::system_clock::time_point kFixedTs =
     std::chrono::system_clock::time_point{std::chrono::hours{12}};
 
@@ -635,6 +636,8 @@ static void run_walk(std::uint64_t seed, int width, int term_h) {
         }
     }
 }
+
+}  // namespace (fold)
 
 int main() {
     std::printf("scrollback_wire_fuzz\n");


### PR DESCRIPTION
Folds the full-stack standalone tests (forkers/PTY/fuzzers/e2e/benches) into ONE binary, `agentty_standalone_tests`, argv-dispatched so each still runs in its own process per ctest entry — isolation identical, ~16 heavy links → 1.

**Mechanism:** per-source `-Dmain=<name>_main` (no edits to the mains) + an X-macro dispatcher recording each test's arity; colliding file-scope symbols moved to anonymous namespaces (ODR-safe); `argv[0]` kept as the real exe path since external_acp_backend_test re-execs itself.

**Result:** test binaries ~27 → 6. Local: builds clean, **ctest 270/270**.

PR for CI validation on GCC/C++26 + Windows before merge.