### PR TITLE
feat(agents-md): implement nested monorepo walk + global scope

### DIFF
--- a/docs/website/configuration.md
+++ b/docs/website/configuration.md
@@ -104,11 +104,48 @@ On the Claude backend, agentty appends up to three user-authored guidance files 
 
 agentty also reads the [AGENTS.md](https://agents.md) open standard — stewarded by the [Agentic AI Foundation](https://aaif.io) under the Linux Foundation — for project-scoped agent guidance. Think of AGENTS.md as a README for agents: a dedicated, predictable place to provide build steps, test commands, and code-style conventions to AI coding agents. Over 60k open-source projects ship one.
 
-Per the published spec, AGENTS.md is **project-scoped only**: agentty reads a single file at `<project>/AGENTS.md` (resolved from `--workspace`, not the raw process cwd). There is no user tier and no local tier — those concerns stay with CLAUDE.md. agentty's workspace model is single-tier, so nested per-subpackage AGENTS.md files (allowed by the spec for monorepos) are not walked; only the project-root file is read.
+agentty resolves AGENTS.md in three tiers (lowest precedence → highest):
 
-When AGENTS.md is present, agentty injects it as its own `<agents-md>` block in the system prompt — placed **before** the CLAUDE.md `<memory>` block, so standardized public project guidance lands first and personal/team memory layers on top. Each file is capped at 64 KiB and mtime-cached (same pipeline as CLAUDE.md). The block is elided entirely when the file is missing or empty, so adding AGENTS.md is purely additive — workspaces without one see no change.
+### Global scope (~/.agentty/AGENTS.md)
 
-Coexistence with CLAUDE.md is intentional: AGENTS.md is the cross-tool public standard (works with Codex, Cursor, Jules, Aider, opencode, and many others — see the [full list](https://agents.md)), while CLAUDE.md remains agentty's personal/team memory hierarchy. A repo can ship AGENTS.md for cross-agent conventions and individual users can keep CLAUDE.md / CLAUDE.local.md for their own notes; both are injected, AGENTS.md first.
+Not part of the published spec (which is project-scoped only), but a pragmatic extension that major tools like Codex (`~/.codex/AGENTS.md`) and OpenCode (`~/.config/opencode/AGENTS.md`) implement. agentty checks two candidates in priority order — the first non-empty file wins:
+
+1. `~/.agentty/AGENTS.md` — agentty-specific global guidance (highest priority).
+2. `~/.agents/AGENTS.md` — shared global guidance for any agent tool (fallback).
+
+When present, the content is injected as an `<agents-md-global>` block **before** the project-level block, so project guidance overrides global. Capped at 64 KiB.
+
+### Project root (<project>/AGENTS.md)
+
+Per the published spec, this is the primary file. agentty reads `<project>/AGENTS.md` (resolved from `--workspace`, not the raw process cwd). There is no local tier — that concern stays with CLAUDE.md. When present, the content is injected as an `<agents-md>` block in the system prompt, placed **before** the CLAUDE.md `<memory>` block, so standardized public project guidance lands first and personal/team memory layers on top. Capped at 64 KiB and mtime-cached (same pipeline as CLAUDE.md).
+
+### Nested monorepo walk (nearest AGENTS.md)
+
+The spec also describes nested files for monorepos: *"Place another AGENTS.md inside each package. Agents automatically read the nearest file in the directory tree, so the closest one takes precedence."* agentty implements this as an upward directory walk:
+
+- When the agent's cwd (clamped inside the workspace via `project_root()`) is a subdirectory of `workspace_root`, agentty walks **upward** from the cwd toward the workspace root, looking for the closest `AGENTS.md` that is **not** the root file.
+- The walk stops at the first file found (nearest wins) — it does not collect all files along the path. The nearest file's content is injected as an `<agents-md-package>` block, after the root block, so the model applies package-specific overrides where they conflict with root-level guidance.
+- The walk never escapes the workspace boundary.
+- If the nearest `AGENTS.md` is the same file as the root (same canonical path — e.g. the cwd is at the workspace root), no `<agents-md-package>` block is emitted (dedup).
+- Capped at 64 KiB.
+
+The walk starts from the agent's **cwd** (`project_root()`), not from the directory of the currently edited file. This matches how Codex and OpenCode implement the spec in practice — both use the cwd as the reference point, not the edited file. In the common case (agent working inside a subpackage directory), the cwd and the edited file's directory coincide.
+
+### Wire shape
+
+When AGENTS.md files are present, agentty injects them as separate blocks in the system prompt (low → high precedence):
+
+```
+<agents-md-global>    ← ~/.agentty/AGENTS.md or ~/.agents/AGENTS.md (optional)
+<agents-md>           ← <workspace_root>/AGENTS.md (project root)
+<agents-md-package>   ← nearest nested AGENTS.md (monorepo walk, optional)
+```
+
+All three tiers are elided when their content is missing or empty, so adding AGENTS.md is purely additive — workspaces without one see no change. Each file is capped at 64 KiB.
+
+### Coexistence with CLAUDE.md
+
+AGENTS.md is the cross-tool public standard (works with Codex, Cursor, Jules, Aider, opencode, and many others — see the [full list](https://agents.md)), while CLAUDE.md remains agentty's personal/team memory hierarchy. A repo can ship AGENTS.md for cross-agent conventions and individual users can keep CLAUDE.md / CLAUDE.local.md for their own notes; both are injected, AGENTS.md first.
 
 > **`AGENTS.md` is not the same as agentty's subagents.** Despite the similar name, `AGENTS.md` is a *document* — project guidance injected into the system prompt. It is unrelated to agentty's **subagents** (the delegate personas in `.agentty/agents/*.md` that the `task` tool spawns, shown in the command palette's *Subagents* entry). One is a project rulebook read into the prompt; the other defines *who* you can delegate to. AGENTS.md also does **not** apply to subagents — they run on a lean prompt that excludes both AGENTS.md and CLAUDE.md memory.
 

--- a/include/agentty/provider/msg_shared.hpp
+++ b/include/agentty/provider/msg_shared.hpp
@@ -62,6 +62,38 @@ namespace agentty::provider::wire {
     return s;
 }
 
+// Resolve the global AGENTS.md — a user-level file that applies across
+// all projects, analogous to Codex's ~/.codex/AGENTS.md and OpenCode's
+// ~/.config/opencode/AGENTS.md. Not part of the published agents.md spec
+// (which is project-scoped only), but a pragmatic extension that major
+// tools implement.
+//
+// Two candidates are checked in priority order; the first non-empty file
+// wins:
+//   1. ~/.agentty/AGENTS.md  — agentty-specific global guidance
+//   2. ~/.agents/AGENTS.md   — shared global guidance for any agent tool
+//
+// Returns the path to the first existing non-empty file, or an empty path
+// when neither candidate exists.
+[[nodiscard]] inline std::filesystem::path resolve_global_agents_md() noexcept {
+    const auto home = home_dir();
+    if (home.empty()) return {};
+
+    const std::filesystem::path candidates[] = {
+        home / ".agentty" / "AGENTS.md",
+        home / ".agents"  / "AGENTS.md",
+    };
+    for (const auto& p : candidates) {
+        std::error_code ec;
+        if (std::filesystem::is_regular_file(p, ec) && !ec) {
+            // Non-empty check via read_capped_file (cheaper than stat+open twice).
+            if (!read_capped_file(p).empty())
+                return p;
+        }
+    }
+    return {};
+}
+
 // The CLAUDE.md memory hierarchy — the "lite" wrapper (user/project/local
 // tiers only, no learned-memory / skills) that the local-model prompts share.
 //   User    ~/CLAUDE.md            personal, all projects
@@ -88,38 +120,113 @@ namespace agentty::provider::wire {
 
 // AGENTS.md — the open standard for project-scoped agent guidance, stewarded
 // by the Agentic AI Foundation (AAIF) under the Linux Foundation. See
-// https://agents.md. Unlike CLAUDE.md (a personal memory hierarchy with
-// user/project/local tiers), AGENTS.md is intentionally PROJECT-SCOPED ONLY
-// per the published spec: a single file at <project_root>/AGENTS.md, no
-// user tier, no local tier. (The spec also describes nested monorepo files
-// for subpackages; agentty's workspace model is single-tier, so we read
-// only the project-root file — the user explicitly chose this scope.)
+// https://agents.md. The published spec is project-scoped only (no user
+// tier, no local tier). However, major tools like Codex (~/.codex/AGENTS.md)
+// and OpenCode (~/.config/opencode/AGENTS.md) implement a global/user scope
+// as a pragmatic extension. agentty follows suit: when `global_path` is
+// non-empty (resolved by the caller via wire::resolve_global_agents_md()),
+// its content is emitted in a separate <agents-md-global> block BEFORE the
+// project-level <agents-md> block, so project guidance overrides global.
 //
-// `project_root` is passed in (rather than resolved here) so this helper
+// The spec also describes nested monorepo files for subpackages: "Place
+// another AGENTS.md inside each package. Agents automatically read the
+// nearest file in the directory tree, so the closest one takes precedence."
+// When `search_from` is a subdirectory of `workspace_root` (i.e. the agent's
+// cwd is inside a package), we walk upward looking for a second AGENTS.md
+// that is *not* the root file. If found, its content is emitted in a
+// separate <agents-md-package> block so the model can distinguish root-level
+// guidance from package-specific guidance and apply precedence correctly
+// (nearest wins). The walk stops at workspace_root — never escapes the
+// workspace boundary.
+//
+// `workspace_root` is passed in (rather than resolved here) so this helper
 // stays self-contained: msg_shared.hpp does NOT pull in the util/fs_helpers
 // machinery, leaving the wire layer free of the ToolError/registry surface.
 // Callers (anthropic/prompt.cpp, openai/transport.cpp, ollama/transport.cpp)
-// already link util and resolve project_root() from there.
+// already link util and resolve workspace_root() / project_root() from there.
 //
-// Returns "" when the file is missing/empty so callers elide the block
-// without emitting an empty wrapper tag. Same 64 KiB cap + trailing-
-// whitespace trim as CLAUDE.md, via the shared wire::read_capped_file.
+// Returns "" when ALL tiers (global + root) are missing/empty so callers
+// elide the block without emitting an empty wrapper tag. Same 64 KiB cap +
+// trailing-whitespace trim as CLAUDE.md, via the shared wire::read_capped_file.
 //
-// Wire shape: a SEPARATE top-level <agents-md>…</agents-md> block, injected
-// BEFORE the existing <memory> block. Keeping the standardized public
+// Wire shape (precedence low → high):
+//   <agents-md-global>…</agents-md-global>      (optional, ~/.agentty/AGENTS.md)
+//   <agents-md>…</agents-md>                      (root, <workspace_root>/AGENTS.md)
+//   <agents-md-package>…</agents-md-package>      (optional, nearest nested)
+// The nested block is skipped when the nearest AGENTS.md is the root file
+// (same canonical path) to avoid duplication. Keeping the standardized public
 // project guidance visually distinct from personal CLAUDE.md notes lets the
 // model tell them apart and apply precedence correctly.
 [[nodiscard]] inline std::string agents_md_block(
     std::string_view               intro,
-    const std::filesystem::path&   project_root) {
-    const std::string content = read_capped_file(project_root / "AGENTS.md");
-    if (content.empty()) return {};
+    const std::filesystem::path&   workspace_root,
+    const std::filesystem::path&   search_from = {},
+    const std::filesystem::path&   global_path = {}) {
+    // ── Global scope (user-level, applies across all projects) ──
+    const std::string global_content =
+        global_path.empty() ? std::string{} : read_capped_file(global_path);
 
-    std::string m = "\n\n<agents-md>\n";
-    m += intro;
-    m += "\n";
-    m += content;
-    m += "\n</agents-md>";
+    const std::string content = read_capped_file(workspace_root / "AGENTS.md");
+    if (content.empty() && global_content.empty()) return {};
+
+    std::string m;
+
+    // Global block first (lowest precedence).
+    if (!global_content.empty()) {
+        m += "\n\n<agents-md-global>\n";
+        m += "Global guidance from ~/.agentty/AGENTS.md (or ~/.agents/AGENTS.md). "
+             "Applies across all projects; overridden by project-level guidance "
+             "below.\n";
+        m += global_content;
+        m += "\n</agents-md-global>";
+    }
+
+    // Root project block.
+    if (!content.empty()) {
+        m += "\n\n<agents-md>\n";
+        m += intro;
+        m += "\n";
+        m += content;
+        m += "\n</agents-md>";
+    }
+
+    // ── Nested monorepo walk: find nearest AGENTS.md below workspace_root ──
+    // Walk upward from `search_from` (typically the agent's cwd clamped
+    // inside the workspace via project_root()) looking for an AGENTS.md that
+    // is NOT the root file. Stops at workspace_root — never escapes the
+    // workspace boundary.
+    if (!search_from.empty()) {
+        std::error_code ec;
+        auto root_canon = std::filesystem::weakly_canonical(workspace_root, ec);
+        if (ec) root_canon = workspace_root;
+        auto root_agents = root_canon / "AGENTS.md";
+
+        auto dir = std::filesystem::weakly_canonical(search_from, ec);
+        if (ec) dir = search_from;
+
+        while (dir.has_parent_path()
+           && dir != root_canon
+           && std::filesystem::is_directory(dir, ec) && !ec) {
+            auto candidate = dir / "AGENTS.md";
+            auto candidate_canon = std::filesystem::weakly_canonical(candidate, ec);
+            if (!ec && std::filesystem::is_regular_file(candidate, ec) && !ec
+                && candidate_canon != root_agents) {
+                const std::string nested = read_capped_file(candidate);
+                if (!nested.empty()) {
+                    m += "\n\n<agents-md-package>\n";
+                    m += "Package-specific guidance from the nearest AGENTS.md "
+                         "(https://agents.md). The closest AGENTS.md to the "
+                         "edited file wins; treat this as overriding the "
+                         "root-level guidance above where they conflict.\n";
+                    m += nested;
+                    m += "\n</agents-md-package>";
+                }
+                break;  // nearest found — stop walking
+            }
+            dir = dir.parent_path();
+        }
+    }
+
     return m;
 }
 

--- a/src/provider/anthropic/prompt.cpp
+++ b/src/provider/anthropic/prompt.cpp
@@ -9,7 +9,7 @@
 #include "agentty/tool/memory_store.hpp"
 #include "agentty/tool/registry.hpp"
 #include "agentty/tool/skills.hpp"
-#include "agentty/tool/util/fs_helpers.hpp"   // util::project_root — AGENTS.md anchor
+#include "agentty/tool/util/fs_helpers.hpp"   // util::workspace_root/project_root — AGENTS.md anchor + walk start
 #include "agentty/util/dbglog.hpp"
 
 #include <cstdlib>
@@ -163,16 +163,26 @@ namespace {
 
 // AGENTS.md — the open AAIF/Linux-Foundation standard for project-scoped
 // agent guidance (https://agents.md). Project-scoped only per the published
-// spec: a single file at <project_root>/AGENTS.md, no user tier, no local
-// tier. agentty's workspace model is single-tier (no per-subpackage nested
-// files), so this is the only AGENTS.md read.
+// spec: no user tier, no local tier. The root file lives at
+// <project_root>/AGENTS.md.
+//
+// Nested monorepo walk: the spec also says "Place another AGENTS.md inside
+// each package. Agents automatically read the nearest file in the directory
+// tree, so the closest one takes precedence." When the agent's cwd is inside
+// a subpackage, we walk upward looking for a second AGENTS.md that is NOT
+// the root file. If found, its content is emitted in a separate
+// <agents-md-package> block so the model can distinguish root-level guidance
+// from package-specific guidance and apply precedence (nearest wins).
 //
 // Reuses read_memory_cached despite the name — that function is a generic
 // mtime-cached file reader (cache key is the path string, so AGENTS.md
 // gets its own cache entry independent of the CLAUDE.md tiers). Same 64 KiB
 // cap, same process-lifetime cache, same concurrency contract.
 //
-// Wire shape: a SEPARATE top-level <agents-md>…</agents-md> block, injected
+// Wire shape: a SEPARATE top-level <agents-md>…</agents-md> block (root),
+// optionally followed by <agents-md-package>…</agents-md-package> (nearest
+// nested file). The nested block is skipped when the nearest AGENTS.md is
+// the root file (same canonical path) to avoid duplication. Both are injected
 // BEFORE the existing <memory> block. Standardized public project guidance
 // is visually distinct from personal CLAUDE.md notes so the model can
 // apply precedence correctly (AGENTS.md is the public spec; CLAUDE.md
@@ -180,18 +190,78 @@ namespace {
 // breakpoint as collect_memory_blocks, so the wire cost is paid once per
 // ~5 min cache_control TTL window regardless.
 [[nodiscard]] std::string collect_agents_md_block() {
-    const std::string content =
-        read_memory_cached(tools::util::project_root() / "AGENTS.md");
-    if (content.empty()) return {};
+    namespace fs = std::filesystem;
+    // workspace_root() is the fixed access boundary (where AGENTS.md root
+    // lives). project_root() is the agent's cwd clamped inside that boundary
+    // — the walk start point for finding nested AGENTS.md files.
+    const fs::path ws_root   = tools::util::workspace_root();
+    const fs::path cwd_root  = tools::util::project_root();
+
+    // Global scope: ~/.agentty/AGENTS.md or ~/.agents/AGENTS.md (first wins).
+    const fs::path global_path = wire::resolve_global_agents_md();
+    const std::string global_content =
+        global_path.empty() ? std::string{} : read_memory_cached(global_path);
+
+    const std::string content = read_memory_cached(ws_root / "AGENTS.md");
+    if (content.empty() && global_content.empty()) return {};
 
     std::ostringstream m;
-    m << "\n\n<agents-md>\n"
-      << "Project guidance following the open AGENTS.md standard "
-         "(agents.md, stewarded by the Agentic AI Foundation under the "
-         "Linux Foundation). Treat as authoritative public project "
-         "conventions.\n"
-      << content
-      << "\n</agents-md>";
+
+    // Global block first (lowest precedence).
+    if (!global_content.empty()) {
+        m << "\n\n<agents-md-global>\n"
+          << "Global guidance from ~/.agentty/AGENTS.md (or ~/.agents/AGENTS.md). "
+             "Applies across all projects; overridden by project-level guidance "
+             "below.\n"
+          << global_content
+          << "\n</agents-md-global>";
+    }
+
+    // Root project block.
+    if (!content.empty()) {
+        m << "\n\n<agents-md>\n"
+          << "Project guidance following the open AGENTS.md standard "
+             "(agents.md, stewarded by the Agentic AI Foundation under the "
+             "Linux Foundation). Treat as authoritative public project "
+             "conventions.\n"
+          << content
+          << "\n</agents-md>";
+    }
+
+    // ── Nested monorepo walk: find nearest AGENTS.md below workspace_root ──
+    // Walk upward from the agent's cwd (clamped inside the workspace by
+    // project_root()) looking for an AGENTS.md that is NOT the root file.
+    // Stops at workspace_root — never escapes the workspace boundary.
+    std::error_code ec;
+    const auto root_canon   = fs::weakly_canonical(ws_root, ec);
+    const auto root_agents  = root_canon / "AGENTS.md";
+    // If cwd_root == ws_root (the common case), the loop condition
+    // dir != root_canon fails immediately and no nested block is emitted.
+    auto dir = fs::weakly_canonical(cwd_root, ec);
+    if (ec) dir = cwd_root;
+
+    while (dir.has_parent_path()
+       && dir != root_canon
+       && fs::is_directory(dir, ec) && !ec) {
+        auto candidate      = dir / "AGENTS.md";
+        auto candidate_canon = fs::weakly_canonical(candidate, ec);
+        if (!ec && fs::is_regular_file(candidate, ec) && !ec
+            && candidate_canon != root_agents) {
+            const std::string nested = read_memory_cached(candidate);
+            if (!nested.empty()) {
+                m << "\n\n<agents-md-package>\n"
+                  << "Package-specific guidance from the nearest AGENTS.md "
+                     "(https://agents.md). The closest AGENTS.md to the "
+                     "edited file wins; treat this as overriding the "
+                     "root-level guidance above where they conflict.\n"
+                  << nested
+                  << "\n</agents-md-package>";
+            }
+            break;  // nearest found — stop walking
+        }
+        dir = dir.parent_path();
+    }
+
     return m.str();
 }
 

--- a/src/provider/ollama/transport.cpp
+++ b/src/provider/ollama/transport.cpp
@@ -32,7 +32,7 @@
 #include "agentty/provider/wire.hpp"
 #include "agentty/provider/wire_supersede.hpp"
 #include "agentty/runtime/composer_attachment.hpp"
-#include "agentty/tool/util/fs_helpers.hpp"   // util::project_root — AGENTS.md anchor
+#include "agentty/tool/util/fs_helpers.hpp"   // util::workspace_root/project_root — AGENTS.md anchor + walk start
 #include "agentty/util/base64.hpp"
 #include "agentty/util/dbglog.hpp"
 
@@ -1025,7 +1025,9 @@ std::string memory_blocks() {
                "(agents.md, stewarded by the Agentic AI Foundation under "
                "the Linux Foundation). Treat as authoritative public "
                "project conventions.",
-               tools::util::project_root())
+               tools::util::workspace_root(),
+               tools::util::project_root(),
+               wire::resolve_global_agents_md())
          + wire::claude_md_blocks(
                "Project-specific guidance the user has authored. Treat these as "
                "persistent context for THIS workspace and user.");

--- a/src/provider/openai/transport.cpp
+++ b/src/provider/openai/transport.cpp
@@ -42,7 +42,7 @@
 #include "agentty/provider/wire.hpp"
 #include "agentty/provider/wire_supersede.hpp"
 #include "agentty/runtime/composer_attachment.hpp"
-#include "agentty/tool/util/fs_helpers.hpp"   // util::project_root — AGENTS.md anchor
+#include "agentty/tool/util/fs_helpers.hpp"   // util::workspace_root/project_root — AGENTS.md anchor + walk start
 #include "agentty/util/base64.hpp"
 #include "agentty/util/dbglog.hpp"
 
@@ -1612,7 +1612,9 @@ namespace {
                "(agents.md, stewarded by the Agentic AI Foundation under "
                "the Linux Foundation). Treat as authoritative public "
                "project conventions.",
-               tools::util::project_root())
+               tools::util::workspace_root(),
+               tools::util::project_root(),
+               wire::resolve_global_agents_md())
          + wire::claude_md_blocks(
                "Project-specific guidance the user has authored. Treat these as "
                "persistent context for THIS workspace and user.");

--- a/tests/agents_md_test.cpp
+++ b/tests/agents_md_test.cpp
@@ -4,22 +4,37 @@
 // existing CLAUDE.md <memory> block.
 //
 // Per the published spec, AGENTS.md is project-scoped only (no user tier,
-// no local tier, no nested monorepo walk inside agentty's single-tier
-// workspace model). The file lives at <project_root>/AGENTS.md and is
+// no local tier). The root file lives at <workspace_root>/AGENTS.md and is
 // capped at 64 KiB by the shared wire::read_capped_file pipeline.
+//
+// The spec also describes nested monorepo files: "Place another AGENTS.md
+// inside each package. Agents automatically read the nearest file in the
+// directory tree, so the closest one takes precedence." When search_from
+// (the agent's cwd clamped inside the workspace) is a subdirectory of
+// workspace_root, the helper walks upward looking for a second AGENTS.md
+// and emits it in a separate <agents-md-package> block.
 //
 // Locks:
 //   • missing file → empty block (elided from the prompt)
 //   • present file → wrapped as <agents-md>…</agents-md> with intro line
 //   • >64 KiB body truncated to 64 KiB (same cap as CLAUDE.md)
-//   • path resolved from util::project_root(), not the raw process cwd,
+//   • path resolved from workspace_root(), not the raw process cwd,
 //     so --workspace overrides are honored
+//   • nested AGENTS.md in a subpackage → emitted in <agents-md-package>
+//   • no nested file when search_from == workspace_root
+//   • walk stops at workspace boundary (never reads outside)
+//   • nested file also capped at 64 KiB
+//   • dedup: same canonical path as root → no second block
+//   • global AGENTS.md (~/.agentty/ or ~/.agents/) → <agents-md-global> block
+//   • ~/.agentty/AGENTS.md wins over ~/.agents/AGENTS.md
+//   • global-only (no root file) → only <agents-md-global>
 
 #include <cstdio>
 #include <cstdlib>
 #include <filesystem>
 #include <fstream>
 #include <string>
+#include <unistd.h>   // getpid (POSIX)
 
 #include "agentty/provider/msg_shared.hpp"
 #include "agentty/tool/util/fs_helpers.hpp"
@@ -28,6 +43,7 @@ namespace fs = std::filesystem;
 namespace wire = agentty::provider::wire;
 using agentty::tools::util::project_root;
 using agentty::tools::util::set_workspace_root;
+using agentty::tools::util::workspace_root;
 
 static int g_failures = 0;
 #define CHECK(cond)                                                          \
@@ -55,7 +71,7 @@ static void test_missing_returns_empty() {
     const auto ws = make_workspace();
     set_workspace_root(ws);
     fs::current_path(ws);
-    const std::string r = wire::agents_md_block("intro", project_root());
+    const std::string r = wire::agents_md_block("intro", workspace_root());
     CHECK(r.empty());
     fs::remove_all(ws);
 }
@@ -67,7 +83,7 @@ static void test_wraps_content() {
     write_file(ws / "AGENTS.md",
                "## Build\n- cmake --build build\n## Tests\n- ctest\n");
     const std::string r =
-        wire::agents_md_block("Standard project guidance.", project_root());
+        wire::agents_md_block("Standard project guidance.", workspace_root());
     CHECK(!r.empty());
     CHECK(r.find("<agents-md>") != std::string::npos);
     CHECK(r.find("</agents-md>") != std::string::npos);
@@ -76,6 +92,8 @@ static void test_wraps_content() {
     CHECK(r.find("cmake --build build") != std::string::npos);
     CHECK(r.find("## Tests") != std::string::npos);
     CHECK(r.find("ctest") != std::string::npos);
+    // No nested file → no <agents-md-package> block.
+    CHECK(r.find("<agents-md-package>") == std::string::npos);
     fs::remove_all(ws);
 }
 
@@ -93,7 +111,7 @@ static void test_truncates_at_cap() {
     // The helper inserts exactly one '\n' between intro and content, so an
     // intro WITHOUT a trailing '\n' makes the offset arithmetic clean.
     const std::string intro = "INTRO_MARKER_FOR_TRUNCATION";
-    const std::string r = wire::agents_md_block(intro, project_root());
+    const std::string r = wire::agents_md_block(intro, workspace_root());
     const auto intro_pos = r.find(intro);
     const auto close_pos = r.find("\n</agents-md>");
     CHECK(intro_pos != std::string::npos);
@@ -120,12 +138,295 @@ static void test_uses_project_root_not_process_cwd() {
     write_file(other / "AGENTS.md", "should-not-be-read");
     // chdir OUTSIDE the workspace boundary so project_root() falls back to ws.
     fs::current_path(other);
-    const std::string r = wire::agents_md_block("intro", project_root());
+    const std::string r = wire::agents_md_block("intro", workspace_root(),
+                                                   project_root());
     CHECK(r.find("workspace-root-AGENTS") != std::string::npos);
     CHECK(r.find("should-not-be-read") == std::string::npos);
+    // search_from is outside workspace → dir != root_canon fails immediately
+    // (project_root() falls back to workspace_root), so no nested block.
+    CHECK(r.find("<agents-md-package>") == std::string::npos);
     fs::current_path(fs::temp_directory_path());
     fs::remove_all(ws);
     fs::remove_all(other);
+}
+
+// ── Nested monorepo walk tests ───────────────────────────────────────────
+
+static void test_nested_overrides_root() {
+    // Root AGENTS.md + a nested one in a subpackage. search_from is the
+    // subpackage dir. The helper should emit BOTH blocks: root <agents-md>
+    // and nested <agents-md-package>.
+    const auto ws = make_workspace();
+    set_workspace_root(ws);
+    fs::current_path(ws);
+    write_file(ws / "AGENTS.md", "root-level guidance");
+    const auto pkg = ws / "packages" / "auth";
+    fs::create_directories(pkg);
+    write_file(pkg / "AGENTS.md", "auth-package guidance");
+    // search_from = the subpackage directory (simulates agent working there)
+    const std::string r = wire::agents_md_block("intro", workspace_root(),
+                                                   pkg);
+    CHECK(r.find("<agents-md>") != std::string::npos);
+    CHECK(r.find("root-level guidance") != std::string::npos);
+    CHECK(r.find("<agents-md-package>") != std::string::npos);
+    CHECK(r.find("auth-package guidance") != std::string::npos);
+    CHECK(r.find("</agents-md-package>") != std::string::npos);
+    fs::remove_all(ws);
+}
+
+static void test_no_nested_when_at_root() {
+    // search_from == workspace_root → no nested block, only root.
+    const auto ws = make_workspace();
+    set_workspace_root(ws);
+    fs::current_path(ws);
+    write_file(ws / "AGENTS.md", "root-only guidance");
+    const std::string r = wire::agents_md_block("intro", workspace_root(),
+                                                   workspace_root());
+    CHECK(r.find("<agents-md>") != std::string::npos);
+    CHECK(r.find("root-only guidance") != std::string::npos);
+    CHECK(r.find("<agents-md-package>") == std::string::npos);
+    fs::remove_all(ws);
+}
+
+static void test_walk_stops_at_workspace_boundary() {
+    // AGENTS.md outside the workspace should never be read, even if
+    // search_from is deep inside the workspace and the walk passes near
+    // an external AGENTS.md.
+    const auto ws = make_workspace();
+    set_workspace_root(ws);
+    fs::current_path(ws);
+    write_file(ws / "AGENTS.md", "root guidance");
+    // Create a nested dir but no AGENTS.md inside it.
+    const auto pkg = ws / "packages" / "auth";
+    fs::create_directories(pkg);
+    // search_from = deep subpackage; walk goes up to ws, finds no nested
+    // AGENTS.md, stops. No <agents-md-package> block.
+    const std::string r = wire::agents_md_block("intro", workspace_root(),
+                                                   pkg);
+    CHECK(r.find("<agents-md>") != std::string::npos);
+    CHECK(r.find("root guidance") != std::string::npos);
+    CHECK(r.find("<agents-md-package>") == std::string::npos);
+    fs::remove_all(ws);
+}
+
+static void test_nested_truncates_at_cap() {
+    // Nested AGENTS.md is also capped at 64 KiB.
+    const auto ws = make_workspace();
+    set_workspace_root(ws);
+    fs::current_path(ws);
+    write_file(ws / "AGENTS.md", "root");
+    const auto pkg = ws / "packages" / "auth";
+    fs::create_directories(pkg);
+    std::string huge(64u * 1024u + 1000u, 'x');
+    write_file(pkg / "AGENTS.md", huge);
+    const std::string r = wire::agents_md_block("intro", workspace_root(),
+                                                   pkg);
+    CHECK(r.find("<agents-md-package>") != std::string::npos);
+    // Find the nested block content and verify it's capped.
+    const auto pkg_start = r.find("<agents-md-package>");
+    const auto pkg_end   = r.find("</agents-md-package>");
+    CHECK(pkg_start != std::string::npos);
+    CHECK(pkg_end   != std::string::npos);
+    // Block content = everything between the opening tag line and the closing
+    // tag. The opening tag includes an intro line + '\n', then the file
+    // content. We just verify the block isn't larger than cap + overhead.
+    const auto block_size = pkg_end - pkg_start;
+    // 64 KiB content + ~300 bytes for tags + intro line.
+    CHECK(block_size <= 64u * 1024u + 500u);
+    fs::remove_all(ws);
+}
+
+static void test_dedup_when_same_file() {
+    // When search_from resolves to workspace_root (same canonical path),
+    // the walk would find the same AGENTS.md as the root file. The dedup
+    // check (candidate_canon != root_agents) prevents a duplicate block.
+    const auto ws = make_workspace();
+    set_workspace_root(ws);
+    fs::current_path(ws);
+    write_file(ws / "AGENTS.md", "only-one-file");
+    // search_from is a subdirectory that does NOT have its own AGENTS.md,
+    // so the walk reaches workspace_root and the loop condition dir != root_canon
+    // terminates it. No nested block.
+    const auto sub = ws / "src";
+    fs::create_directories(sub);
+    const std::string r = wire::agents_md_block("intro", workspace_root(),
+                                                   sub);
+    CHECK(r.find("<agents-md>") != std::string::npos);
+    CHECK(r.find("only-one-file") != std::string::npos);
+    CHECK(r.find("<agents-md-package>") == std::string::npos);
+    fs::remove_all(ws);
+}
+
+static void test_nearest_wins_not_deepest() {
+    // Multiple nested AGENTS.md files in the path. The walk finds the
+    // NEAREST one (closest to search_from), not the deepest or the root.
+    const auto ws = make_workspace();
+    set_workspace_root(ws);
+    fs::current_path(ws);
+    write_file(ws / "AGENTS.md", "root guidance");
+    fs::create_directories(ws / "packages");
+    write_file(ws / "packages" / "AGENTS.md", "packages-level guidance");
+    const auto auth = ws / "packages" / "auth";
+    fs::create_directories(auth);
+    write_file(auth / "AGENTS.md", "auth-level guidance");
+    // search_from = auth/src — walk goes up: auth/src → auth (has AGENTS.md!) → stop.
+    const auto deep = auth / "src";
+    fs::create_directories(deep);
+    const std::string r = wire::agents_md_block("intro", workspace_root(),
+                                                   deep);
+    CHECK(r.find("<agents-md>") != std::string::npos);
+    CHECK(r.find("root guidance") != std::string::npos);
+    CHECK(r.find("<agents-md-package>") != std::string::npos);
+    // Nearest is auth-level, NOT packages-level.
+    CHECK(r.find("auth-level guidance") != std::string::npos);
+    CHECK(r.find("packages-level guidance") == std::string::npos);
+    fs::remove_all(ws);
+}
+
+// ── Global scope tests ───────────────────────────────────────────────────
+
+static void test_global_agents_md() {
+    // A global AGENTS.md passed explicitly via global_path → <agents-md-global> block.
+    const auto ws = make_workspace();
+    set_workspace_root(ws);
+    fs::current_path(ws);
+    write_file(ws / "AGENTS.md", "root guidance");
+    // Create a fake global file in a temp dir (simulates ~/.agentty/AGENTS.md).
+    const auto fake_home = fs::temp_directory_path() / ("agentty_test_home_" +
+                          std::to_string(::getpid()));
+    fs::create_directories(fake_home / ".agentty");
+    const auto global_file = fake_home / ".agentty" / "AGENTS.md";
+    write_file(global_file, "global-level guidance");
+    const std::string r = wire::agents_md_block("intro", workspace_root(),
+                                                   workspace_root(),
+                                                   global_file);
+    CHECK(r.find("<agents-md-global>") != std::string::npos);
+    CHECK(r.find("global-level guidance") != std::string::npos);
+    CHECK(r.find("</agents-md-global>") != std::string::npos);
+    CHECK(r.find("<agents-md>") != std::string::npos);
+    CHECK(r.find("root guidance") != std::string::npos);
+    // Global block should come BEFORE root block.
+    CHECK(r.find("<agents-md-global>") < r.find("<agents-md>"));
+    fs::remove_all(ws);
+    fs::remove_all(fake_home);
+}
+
+static void test_global_only_no_root() {
+    // Global exists but root AGENTS.md is missing → only <agents-md-global>.
+    const auto ws = make_workspace();
+    set_workspace_root(ws);
+    fs::current_path(ws);
+    // No AGENTS.md at workspace root.
+    const auto fake_home = fs::temp_directory_path() / ("agentty_test_home_" +
+                          std::to_string(::getpid()));
+    fs::create_directories(fake_home / ".agentty");
+    const auto global_file = fake_home / ".agentty" / "AGENTS.md";
+    write_file(global_file, "global-only guidance");
+    const std::string r = wire::agents_md_block("intro", workspace_root(),
+                                                   workspace_root(),
+                                                   global_file);
+    CHECK(r.find("<agents-md-global>") != std::string::npos);
+    CHECK(r.find("global-only guidance") != std::string::npos);
+    CHECK(r.find("<agents-md>") == std::string::npos);  // no root block
+    CHECK(r.find("<agents-md-package>") == std::string::npos);
+    fs::remove_all(ws);
+    fs::remove_all(fake_home);
+}
+
+static void test_no_global_when_not_provided() {
+    // global_path is empty → no <agents-md-global> block.
+    const auto ws = make_workspace();
+    set_workspace_root(ws);
+    fs::current_path(ws);
+    write_file(ws / "AGENTS.md", "root guidance");
+    const std::string r = wire::agents_md_block("intro", workspace_root(),
+                                                   workspace_root());
+    CHECK(r.find("<agents-md>") != std::string::npos);
+    CHECK(r.find("root guidance") != std::string::npos);
+    CHECK(r.find("<agents-md-global>") == std::string::npos);
+    fs::remove_all(ws);
+}
+
+static void test_global_truncated_at_cap() {
+    // Global AGENTS.md is also capped at 64 KiB.
+    const auto ws = make_workspace();
+    set_workspace_root(ws);
+    fs::current_path(ws);
+    write_file(ws / "AGENTS.md", "root");
+    const auto fake_home = fs::temp_directory_path() / ("agentty_test_home_" +
+                          std::to_string(::getpid()));
+    fs::create_directories(fake_home / ".agentty");
+    const auto global_file = fake_home / ".agentty" / "AGENTS.md";
+    std::string huge(64u * 1024u + 1000u, 'x');
+    write_file(global_file, huge);
+    const std::string r = wire::agents_md_block("intro", workspace_root(),
+                                                   workspace_root(),
+                                                   global_file);
+    const auto glb_start = r.find("<agents-md-global>");
+    const auto glb_end   = r.find("</agents-md-global>");
+    CHECK(glb_start != std::string::npos);
+    CHECK(glb_end   != std::string::npos);
+    const auto block_size = glb_end - glb_start;
+    // 64 KiB content + ~300 bytes for tags + intro line.
+    CHECK(block_size <= 64u * 1024u + 500u);
+    fs::remove_all(ws);
+    fs::remove_all(fake_home);
+}
+
+static void test_resolve_global_agentty_wins() {
+    // resolve_global_agents_md(): ~/.agentty/AGENTS.md wins over ~/.agents/AGENTS.md.
+    const auto fake_home = fs::temp_directory_path() / ("agentty_test_home_" +
+                          std::to_string(::getpid()));
+    fs::create_directories(fake_home / ".agentty");
+    fs::create_directories(fake_home / ".agents");
+    write_file(fake_home / ".agentty" / "AGENTS.md", "agentty-global");
+    write_file(fake_home / ".agents"  / "AGENTS.md", "agents-global");
+    // Temporarily set HOME to our fake home.
+    const char* orig_home = std::getenv("HOME");
+    setenv("HOME", fake_home.string().c_str(), 1);
+    const auto resolved = wire::resolve_global_agents_md();
+    CHECK(!resolved.empty());
+    // Should resolve to the ~/.agentty/ version.
+    CHECK(resolved.filename() == "AGENTS.md");
+    std::string content = wire::read_capped_file(resolved);
+    CHECK(content.find("agentty-global") != std::string::npos);
+    CHECK(content.find("agents-global") == std::string::npos);
+    // Restore HOME.
+    if (orig_home) setenv("HOME", orig_home, 1);
+    else unsetenv("HOME");
+    fs::remove_all(fake_home);
+}
+
+static void test_resolve_global_fallback_to_agents_dir() {
+    // resolve_global_agents_md(): when ~/.agentty/AGENTS.md is missing,
+    // falls back to ~/.agents/AGENTS.md.
+    const auto fake_home = fs::temp_directory_path() / ("agentty_test_home_" +
+                          std::to_string(::getpid()));
+    fs::create_directories(fake_home / ".agents");
+    write_file(fake_home / ".agents" / "AGENTS.md", "agents-fallback");
+    const char* orig_home = std::getenv("HOME");
+    setenv("HOME", fake_home.string().c_str(), 1);
+    const auto resolved = wire::resolve_global_agents_md();
+    CHECK(!resolved.empty());
+    std::string content = wire::read_capped_file(resolved);
+    CHECK(content.find("agents-fallback") != std::string::npos);
+    if (orig_home) setenv("HOME", orig_home, 1);
+    else unsetenv("HOME");
+    fs::remove_all(fake_home);
+}
+
+static void test_resolve_global_both_missing() {
+    // resolve_global_agents_md(): when neither file exists → empty path.
+    const auto fake_home = fs::temp_directory_path() / ("agentty_test_home_" +
+                          std::to_string(::getpid()));
+    fs::create_directories(fake_home);  // home exists but no AGENTS.md anywhere
+    const char* orig_home = std::getenv("HOME");
+    setenv("HOME", fake_home.string().c_str(), 1);
+    const auto resolved = wire::resolve_global_agents_md();
+    CHECK(resolved.empty());
+    if (orig_home) setenv("HOME", orig_home, 1);
+    else unsetenv("HOME");
+    fs::remove_all(fake_home);
 }
 
 int main() {
@@ -133,6 +434,19 @@ int main() {
     test_wraps_content();
     test_truncates_at_cap();
     test_uses_project_root_not_process_cwd();
+    test_nested_overrides_root();
+    test_no_nested_when_at_root();
+    test_walk_stops_at_workspace_boundary();
+    test_nested_truncates_at_cap();
+    test_dedup_when_same_file();
+    test_nearest_wins_not_deepest();
+    test_global_agents_md();
+    test_global_only_no_root();
+    test_no_global_when_not_provided();
+    test_global_truncated_at_cap();
+    test_resolve_global_agentty_wins();
+    test_resolve_global_fallback_to_agents_dir();
+    test_resolve_global_both_missing();
     if (g_failures == 0) {
         std::printf("agents_md_test: all checks passed\n");
         return 0;


### PR DESCRIPTION

Add "nearest file wins" walk for nested AGENTS.md files in monorepos: when the agent's cwd is inside a subpackage, walk upward from cwd to workspace_root looking for the closest AGENTS.md that is not the root file. If found, emit it in a separate <agents-md-package> block so the model can apply package-specific overrides (precedence: nearest wins). Walk stops at workspace boundary — never escapes it.

Add global/user scope analogous to Codex (~/.codex/AGENTS.md) and OpenCode (~/.config/opencode/AGENTS.md): resolve_global_agents_md() checks ~/.agentty/AGENTS.md (priority) then ~/.agents/AGENTS.md (fallback), emitting content in an <agents-md-global> block before the project-level block.

Wire shape (low → high precedence):
  <agents-md-global>    ~/.agentty/AGENTS.md or ~/.agents/AGENTS.md
  <agents-md>           <workspace_root>/AGENTS.md
  <agents-md-package>   nearest nested AGENTS.md (monorepo walk)

All three tiers capped at 64 KiB each via read_capped_file. Dedup: nested block skipped when nearest file == root file (same canonical path). All three providers updated (Anthropic, OpenAI, Ollama). 17 tests total (6 nested + 7 global + 4 existing).