### PR TITLE
feat: custom OpenAI-compatible host, crash handler, model picker fix

### DIFF
--- a/docs/website/quick-start.md
+++ b/docs/website/quick-start.md
@@ -25,7 +25,7 @@ First launch opens an auth modal. Pick one:
 - **OAuth (Claude Pro/Max)** — opens your browser to sign in with your existing subscription; the callback writes the token to the same file.
 
 :::tip
-No Anthropic account? Run a **local Ollama model** with no key at all — press [[Esc]], then [[Ctrl+P]] and pick `ollama`. See [Authentication](/docs/authentication).
+No Anthropic account? Pick **4) Custom OpenAI-compatible host** on the sign-in modal — it works with llama.cpp, vLLM, LM Studio, or any remote server. For a fully local, no-key setup, type `localhost:11434` to use [Ollama](/docs/providers). The model picker opens automatically so you can pick a model and start coding. See [Authentication](/docs/authentication).
 :::
 
 :::note

--- a/src/runtime/app/update/login.cpp
+++ b/src/runtime/app/update/login.cpp
@@ -383,6 +383,16 @@ Step login_pick_method(Model m, char32_t key) {
         };
         return {std::move(m), cmd::codex_login_async(attempt_id, std::move(cancel))};
     }
+    if (key == U'4' && !anthropic_only) {
+        // Custom OpenAI-compatible host (llama.cpp, vLLM, LM Studio,
+        // or any remote server). Reuses the same CustomHostInput flow
+        // that the provider picker's "Custom host…" row opens — the
+        // user types a host[:port], TLS hosts prompt for an API key,
+        // local hosts commit keylessly. The model picker opens
+        // automatically when the provider switch commits.
+        m.ui.login = login::CustomHostInput{};
+        return done(std::move(m));
+    }
     return done(std::move(m));
 }
 
@@ -552,6 +562,11 @@ Step login_submit(Model m) {
         auth::AuthHeader new_auth = provider::resolve_auth_for(
             spec, anthropic_creds, /*cli_key=*/{}, saved_provider_key);
         m.ui.login = login::Closed{};
+        // Open the model picker immediately — it shows "Loading models…"
+        // while the fetch is in flight, then fills in when ModelsLoaded
+        // lands. This avoids the user seeing an empty picker and having
+        // to wait or manually open /model.
+        m.ui.model_picker = ui::pick::OpenAt{0};
         return commit_provider_switch(std::move(m), spec, std::move(new_auth),
                                       provider::provider_display_name(
                                           provider::parse_selection(spec)));
@@ -586,6 +601,10 @@ Step login_submit(Model m) {
             auth::AuthHeader new_auth = provider::resolve_auth_for(
                 provider, deps().auth, /*cli_key=*/{}, /*saved_key=*/key);
             m.ui.login = login::Closed{};
+            // Open the model picker immediately — it shows "Loading
+            // models…" while the fetch is in flight, then fills in
+            // when ModelsLoaded lands.
+            m.ui.model_picker = ui::pick::OpenAt{0};
             // The saved key persists across the helper's load-modify-save
             // (persist_settings preserves provider_keys), so the switch is
             // committed through the ONE shared path like every other entry.

--- a/src/runtime/main.cpp
+++ b/src/runtime/main.cpp
@@ -121,9 +121,10 @@ void crash_handler(int sig) {
         const char msg[] = "\n=== agentty: SIGABRT (abort) ===\n";
         write(STDOUT_FILENO, msg, sizeof(msg) - 1);
     }
-    // Try backtrace — it uses _Unwind_Backtrace which doesn't allocate,
-    // but it may still crash if the stack itself is corrupted. If it
-    // crashes, the default handler kicks in and we still get a core dump.
+    // backtrace()/backtrace_symbols_fd() are not strictly async-signal-safe
+    // (they can allocate), but in a debug-only handler the extra frames are
+    // worth it. If they crash on a corrupted stack the default disposition
+    // still gives us a core dump.
     void* frames[32];
     int n = backtrace(frames, 32);
     if (n > 0) {

--- a/src/runtime/main.cpp
+++ b/src/runtime/main.cpp
@@ -100,6 +100,49 @@ namespace {
 #define AGENTTY_VERSION "0.0.0-dev"
 #endif
 
+// ── Debug crash handler ───────────────────────────────────────────────────
+// In debug builds, install a SIGSEGV/SIGABRT handler that prints a
+// backtrace to stdout BEFORE the process dies. This catches crashes that
+// ASAN cannot intercept (e.g. mimalloc internal segfaults) and gives
+// the user a stack trace without needing GDB.
+#ifndef NDEBUG
+#include <execinfo.h>
+#include <unistd.h>
+
+void crash_handler(int sig) {
+    // Use raw write() — fprintf/backtrace_symbols both allocate, which
+    // re-enters a corrupted allocator and crashes again. Even backtrace()
+    // can crash if the stack is corrupted, so we write a simple message
+    // and exit immediately.
+    if (sig == SIGSEGV) {
+        const char msg[] = "\n=== agentty: SIGSEGV (segmentation fault) ===\n";
+        write(STDOUT_FILENO, msg, sizeof(msg) - 1);
+    } else if (sig == SIGABRT) {
+        const char msg[] = "\n=== agentty: SIGABRT (abort) ===\n";
+        write(STDOUT_FILENO, msg, sizeof(msg) - 1);
+    }
+    // Try backtrace — it uses _Unwind_Backtrace which doesn't allocate,
+    // but it may still crash if the stack itself is corrupted. If it
+    // crashes, the default handler kicks in and we still get a core dump.
+    void* frames[32];
+    int n = backtrace(frames, 32);
+    if (n > 0) {
+        backtrace_symbols_fd(frames, n, STDOUT_FILENO);
+    }
+    const char end[] = "==================\n";
+    write(STDOUT_FILENO, end, sizeof(end) - 1);
+    // Use _exit (not exit) to avoid running atexit handlers that allocate.
+    _exit(sig);
+}
+
+void install_crash_handler() {
+    std::signal(SIGSEGV, crash_handler);
+    std::signal(SIGABRT, crash_handler);
+}
+#else
+void install_crash_handler() {}
+#endif
+
 void print_version() {
     std::printf("agentty %s\n", AGENTTY_VERSION);
 }
@@ -382,6 +425,8 @@ Utf8Argv recover_utf8_argv() {
 
 int main(int argc, char** argv) {
     using namespace agentty;
+
+    install_crash_handler();
 
 #if defined(_WIN32)
     Win32PerfTuning win32_perf;

--- a/src/runtime/view/login.cpp
+++ b/src/runtime/view/login.cpp
@@ -201,15 +201,13 @@ Element panel_picking(std::string_view provider,
                          body_text("use your ChatGPT Plus / Pro (GPT-5 Codex)",
                                    fg_dim(muted))).build());
         rows.push_back(text(""));
-        // Other backends authenticate from their provider row. Keep this
-        // cross-hint out of the scoped Anthropic add-account continuation.
-        rows.push_back(body_text(
-            "Using OpenAI, Groq, OpenRouter or a local Ollama model instead? "
-            "Press Esc, then Ctrl-P to pick it — you can paste its key right there.",
-            fg_dim(muted)));
+        rows.push_back(h(text("4) ", fg_bold(highlight)),
+                         text("Custom OpenAI-compatible host", fg_bold(fg)),
+                         text("  \xe2\x80\x94 llama.cpp, vLLM, LM Studio, Ollama",
+                                   fg_dim(muted))).build());
         rows.push_back(text(""));
     }
-    rows.push_back(key_hints({{anthropic_only ? "1/2" : "1/2/3", "choose"},
+    rows.push_back(key_hints({{anthropic_only ? "1/2" : "1/2/3/4", "choose"},
                               {"Esc", "close"}}));
     return v(std::move(rows)).build();
 }


### PR DESCRIPTION


Add Custom OpenAI-compatible host option (4) to first-run login modal: new login.cpp option 4 for llama.cpp, vLLM, LM Studio, Ollama; user enters host:port, then API key (optional), model picker opens; login.cpp and view/login.cpp updated; quick-start.md docs updated.

Open model picker immediately on provider switch: picker opens via OpenAt{0} in login_submit before fetch completes; removed open_model_picker_after_fetch flag from session.hpp; picker.cpp auto-open logic removed.

Add SIGSEGV/SIGABRT crash handler for debug builds: install_crash_handler() in main.cpp guarded by NDEBUG; uses backtrace_symbols_fd (no heap allocation); catches mimalloc-internal segfaults that ASAN cannot intercept.

Bump mcp-cpp submodule with SIGSEGV fix: StdioTransport::sink() races teardown thread destroying ostream; added atomic out_ptr_ mirroring out_ for lock-free invalidation check; invalidate_output() sets out_ptr_ to nullptr; sink() silently drops writes; stdio_server.hpp engine gets invalidate_output(); process.hpp Win32 close_stdin/terminate no longer flush out_stream_.