### PR TITLE
build(mingw): port execinfo/getpid usage for MSYS2 clang64

### DIFF
--- a/src/runtime/main.cpp
+++ b/src/runtime/main.cpp
@@ -45,9 +45,19 @@
 #include <unistd.h>   // isatty (headless `run` stdin detection)
 #else
 #include <io.h>
+#include <process.h>  // _getpid
 #define isatty _isatty
 #define fileno _fileno
 #endif
+
+// Portable process-id helper (POSIX getpid / Windows _getpid).
+[[nodiscard]] inline long agentty_pid() {
+#ifdef _WIN32
+    return static_cast<long>(::_getpid());
+#else
+    return static_cast<long>(::getpid());
+#endif
+}
 
 #include <maya/maya.hpp>
 
@@ -105,7 +115,7 @@ namespace {
 // backtrace to stdout BEFORE the process dies. This catches crashes that
 // ASAN cannot intercept (e.g. mimalloc internal segfaults) and gives
 // the user a stack trace without needing GDB.
-#ifndef NDEBUG
+#if !defined(NDEBUG) && !defined(_WIN32) && !defined(__MINGW32__) && !defined(__MINGW64__)
 #include <execinfo.h>
 #include <unistd.h>
 
@@ -926,7 +936,7 @@ int main(int argc, char** argv) {
         if (std::freopen(logpath.string().c_str(), "a", stderr)) {
             std::setvbuf(stderr, nullptr, _IOLBF, 0);   // line-buffered
             std::fprintf(stderr, "\n=== agentty session %ld ===\n",
-                         static_cast<long>(::getpid()));
+                          static_cast<long>(agentty_pid()));
         }
     }
 

--- a/src/tool/hooks.cpp
+++ b/src/tool/hooks.cpp
@@ -38,7 +38,9 @@
 
 #ifndef _WIN32
 #include <sys/stat.h>   // chmod
-#include <unistd.h>
+#include <unistd.h>     // getpid
+#else
+#include <process.h>    // _getpid
 #endif
 
 namespace fs = std::filesystem;
@@ -51,6 +53,14 @@ namespace {
 constexpr std::size_t kMaxHooksFileBytes = 64 * 1024;
 constexpr std::size_t kMaxPayloadBytes   = 4 * 1024 * 1024;
 constexpr auto        kHookTimeout       = std::chrono::seconds{30};
+
+[[nodiscard]] inline std::uint64_t current_pid() {
+#ifdef _WIN32
+    return static_cast<std::uint64_t>(::_getpid());
+#else
+    return static_cast<std::uint64_t>(::getpid());
+#endif
+}
 
 struct HookEntry {
     std::string match;   // ERE on the tool name
@@ -188,7 +198,7 @@ void store_approval(const HooksFile& hf) {
     std::error_code ec;
     auto dir = fs::temp_directory_path(ec);
     if (ec) return {};
-    auto p = dir / ("agentty_hook_" + std::to_string(::getpid()) + "_" +
+    auto p = dir / ("agentty_hook_" + std::to_string(current_pid()) + "_" +
                     std::to_string(reinterpret_cast<std::uintptr_t>(&payload)));
     std::ofstream f(p, std::ios::binary | std::ios::trunc);
     if (!f) return {};


### PR DESCRIPTION
Compiles cleanly on Windows with MSYS2 clang64 (clang 22.1.8, x86_64-w64-windows-gnu, C++26, Ninja generator, dev preset). Two POSIX-only APIs were absent on MinGW and broke the build:

- src/runtime/main.cpp: the debug crash handler uses <execinfo.h>
  (backtrace/backtrace_symbols_fd) and ::getpid(), neither of which
  exist on Windows. Gate the whole crash-handler block on
  !defined(_WIN32) so the existing empty #else fallback takes over,
  and replace ::getpid() with an agentty_pid() helper that dispatches
  to _getpid() under _WIN32.
- src/tool/hooks.cpp: the payload temp-file name used ::getpid(). Add a current_pid() helper (getpid on POSIX, _getpid on Windows via <process.h>) and use it instead.

Behavior on POSIX is unchanged; Windows now falls back to the same no-crash-handler / no-chmod paths the Release build already used.