### PR TITLE
fix(picker): custom hosts lost their models menu entry

### DIFF
--- a/src/runtime/app/update/picker.cpp
+++ b/src/runtime/app/update/picker.cpp
@@ -624,6 +624,38 @@ void refresh_fused_sources(Model& m) {
             c->state = ProviderCatalog::State::Ready;
         }
     }
+
+    // SAVED CUSTOM HOSTS are the fused picker's second source. They have no
+    // registry row, so the loop above never created a catalog for them — and
+    // until cb5847aa retired the classic model picker (which read the active
+    // provider's list straight out of available_models), that was survivable:
+    // the fused picker simply never showed them. Now that the fused picker is
+    // the ONLY models menu, a custom host MUST have a catalog here or its
+    // models can never appear: the live fetch lands in available_models, the
+    // picker rebuilds from provider_catalogs, and no row is emitted. Symmetry
+    // with the preset loop: the ACTIVE host mirrors available_models (Ready);
+    // every other saved host starts Idle so Open's deferred wave fetches it
+    // through cmd::fetch_models_for(spec), which resolves its saved key.
+    // (provider_keys membership IS the auth test for a custom host — see
+    // provider_is_authed(id, settings) — so nothing needs a sign-in offer.)
+    for (const auto& spec : provider::saved_custom_hosts(settings.provider_keys)) {
+        ProviderCatalog* c = find_cat(spec);
+        if (!c) {
+            m.d.provider_catalogs.push_back(ProviderCatalog{
+                spec,
+                provider::provider_display_name(
+                    provider::parse_selection(spec)),
+                ProviderCatalog::State::Idle, {}, {}});
+            c = &m.d.provider_catalogs.back();
+        }
+        if (spec == active_pid && !m.d.available_models.empty()) {
+            if (c->models != m.d.available_models) {
+                c->models = m.d.available_models;
+                c->invalidate_derived();    // model set changed — all caches stale
+            }
+            c->state = ProviderCatalog::State::Ready;
+        }
+    }
 }
 
 } // namespace

--- a/tests/provider_model_switch_test.cpp
+++ b/tests/provider_model_switch_test.cpp
@@ -1160,3 +1160,99 @@ TEST_CASE("SignOut with no saved fallback opens sign-in") {
         provider::active().openai_endpoint.label != "openrouter";
     CHECK((opened_signin || switched_away));
 }
+
+// ── Regression: custom-host models in the fused picker ───────────────────────
+// cb5847aa retired the classic per-provider model picker (which read the
+// active provider's list straight out of available_models) and made the
+// fused cross-provider picker the ONLY models menu. But the fused picker
+// reads provider_catalogs, and refresh_fused_sources enumerated ONLY
+// registry presets — a saved custom host never got a catalog, so its live
+// /v1/models fetch landed in available_models and the menu still showed
+// nothing. These cases pin the restored behaviour through the REAL reducer:
+// the active custom host's catalog mirrors available_models (rows appear),
+// and a non-active saved custom host gets a catalog that a FusedCatalogLoaded
+// can merge into.
+TEST_CASE("fused picker shows an active custom host's models") {
+    using namespace agentty::msg;
+    install_stub_deps();
+    g_settings = store::Settings{};
+    // A saved custom host (provider_keys key that is not a registry preset)
+    // is the ACTIVE provider, with a live catalog already in hand.
+    g_settings.provider_keys["my-box.lan:8080"] = "";   // keyless local host
+    provider::select(provider::parse_selection("my-box.lan:8080"));
+
+    Model m;
+    m.d.model_id = ModelId{"qwen3:32b"};
+    m.d.available_models = {mi("qwen3:32b", "my-box.lan:8080"),
+                            mi("llama3.3:70b", "my-box.lan:8080")};
+
+    auto [m1, c1] = app::update(std::move(m), Msg{OpenFusedPicker{}});
+    CHECK(m1.ui.overlay.is<ov::FusedPicker>());
+
+    // The custom host has a catalog, it is the ACTIVE one, and it mirrors
+    // the live list (Ready, non-empty) — the exact seeding contract the
+    // presets get on open.
+    bool host_ready = false;
+    for (const auto& c : m1.d.provider_catalogs) {
+        if (c.provider_id == "my-box.lan:8080") {
+            host_ready = c.state == ProviderCatalog::State::Ready
+                       && c.models.size() == 2;
+        }
+    }
+    CHECK(host_ready, "active custom host catalog mirrors available_models");
+
+    // …and therefore ROWS: the models menu actually lists the host's models.
+    CHECK(!m1.d.fused_rows.empty());
+    bool saw_qwen = false, saw_llama = false;
+    for (const auto& r : m1.d.fused_rows) {
+        if (r.provider_id == "my-box.lan:8080") {
+            if (r.model.id.value == "qwen3:32b") saw_qwen = true;
+            if (r.model.id.value == "llama3.3:70b") saw_llama = true;
+        }
+    }
+    CHECK(saw_qwen);
+    CHECK(saw_llama);
+}
+
+TEST_CASE("fused picker gives a non-active saved custom host a mergeable catalog") {
+    using namespace agentty::msg;
+    install_stub_deps();
+    g_settings = store::Settings{};
+    // Anthropic active; the custom host is saved but NOT active. provider_keys
+    // membership is the auth test for a custom host, so it must appear as a
+    // source — Idle, empty, ready for cmd::fetch_models_for to fill.
+    g_settings.provider_keys["anthropic"]     = "sk-test";
+    g_settings.provider_keys["api.my-gw.com"] = "sk-gw";
+    provider::select(provider::parse_selection("anthropic"));
+
+    Model m;
+    m.d.model_id = ModelId{"claude-sonnet-4-6"};
+    m.d.available_models = {mi("claude-sonnet-4-6", "anthropic")};
+
+    auto [m1, c1] = app::update(std::move(m), Msg{OpenFusedPicker{}});
+    bool gw_idle = false;
+    for (const auto& c : m1.d.provider_catalogs) {
+        if (c.provider_id == "api.my-gw.com")
+            gw_idle = c.state == ProviderCatalog::State::Idle
+                   && c.models.empty();
+    }
+    CHECK(gw_idle, "saved non-active custom host has an Idle catalog");
+
+    // The deferred wave's fetch lands: merge by provider_id, then rows show.
+    FusedCatalogLoaded gw;
+    gw.provider_id = "api.my-gw.com";
+    gw.models = {mi("some-model-x", "api.my-gw.com")};
+    gw.ok = true;
+    auto [m2, c2] = app::update(std::move(m1), Msg{std::move(gw)});
+    bool gw_ready = false;
+    for (const auto& c : m2.d.provider_catalogs)
+        if (c.provider_id == "api.my-gw.com")
+            gw_ready = c.state == ProviderCatalog::State::Ready
+                    && c.models.size() == 1;
+    CHECK(gw_ready);
+    bool saw_gw_model = false;
+    for (const auto& r : m2.d.fused_rows)
+        if (r.provider_id == "api.my-gw.com"
+            && r.model.id.value == "some-model-x") saw_gw_model = true;
+    CHECK(saw_gw_model, "merged custom-host catalog yields rows");
+}


### PR DESCRIPTION
# PR: fix(picker) — custom hosts lost their models menu entry

**Branch:** `fix/custom-host-models-menu` (fork: `sail3r/agentty`)
**Base:** `master` @ `a02ee692` (upstream `1ay1/agentty`)
**Patch files:** `custom-host-models.patch` (plain `git diff master fix/custom-host-models-menu`) · `0001-fix-picker-custom-hosts-lost-their-models-menu-entr.patch` (`git format-patch -1`, applies with `git am`)

---

## Title

```
fix(picker): custom hosts lost their models menu entry
```

## Summary

Between `023d396` and HEAD, the models menu stopped showing *any* models for a
**custom host provider** (a saved OpenAI-compatible endpoint — llama.cpp, vLLM,
LM Studio, Ollama on a LAN box, or an https gateway). The host is reachable,
the key is saved, the `/v1/models` fetch succeeds on the wire — and the menu
renders nothing, with no error. This PR restores custom hosts as a first-class
source of the models menu.

## Root cause

Two commits interacted to produce the regression:

1. **`cb5847aa` — "picker: one model surface, not two"** retired the classic
   per-provider model picker (`ov::ModelPicker`). The classic picker read the
   active provider's list straight out of `m.d.available_models`, which works
   for *any* provider — preset or custom host. After this commit, the fused
   cross-provider picker became **the only models menu**.

2. The fused picker reads **`m.d.provider_catalogs`** — a merged, multi-provider
   catalog view whose rows are seeded exclusively by
   `refresh_fused_sources()` (`src/runtime/app/update/picker.cpp`). That
   function enumerated **only registry presets** (`provider::providers()`).
   A saved custom host is a `settings.provider_keys` key that matches **no**
   registry preset, so it never got a `ProviderCatalog`.

Result: the fetch pipeline still ran end-to-end —

| step | path | status |
| ------ | ------ | -------- |
| switch to host | `commit_provider_switch` → opens FusedPicker, fires `cmd::fetch_models()` | ✔ works |
| fetch | `list_models_for` → `openai::list_models(auth, endpoint)` — resolves the saved key via `credentials::resolve(label)` | ✔ works |
| install | `ModelsLoaded` reducer → `available_models` filled | ✔ works |
| **render** | picker rebuilds rows from `provider_catalogs` — **no catalog exists for the host** | ✘ **empty menu, no error** |

— but the last mile was unsourced, and *"fetched but unsourced"* is
indistinguishable from *"this host has no models"*.

## The fix (32 lines, one function)

`refresh_fused_sources()` gains a **second enumeration over
`provider::saved_custom_hosts(settings.provider_keys)`**, symmetric with the
preset loop:

- **The active custom host** mirrors `available_models` into its catalog and is
  marked `Ready` — the exact seeding contract active presets get on open. The
  live fetch the provider switch already fired lands in `available_models`,
  the next `rebuild_fused_rows` picks the mirror up, and the rows appear.
- **Every other saved custom host** gets an empty `Idle` catalog. Open's
  deferred wave (`FusedRefreshOthers`) fetches it via
  `cmd::fetch_models_for(spec)` — which resolves the host's saved key through
  `provider::credentials::resolve` — and `FusedCatalogLoaded` merges by
  `provider_id`. Rows appear as each host resolves.
- **No sign-in offer** is needed: `provider_keys` membership *is* the auth test
  for a custom host (see `provider_is_authed(id, settings)`).

No identity, endpoint, or credential logic changes: `parse_selection` /
`Endpoint::from_spec` / `credentials::resolve` were already correct for custom
hosts — the picker just never enumerated them.

## Verification

- **New reducer-level regression tests** (`tests/provider_model_switch_test.cpp`,
  +96 lines) drive the **real** `app::update`:
  - *fused picker shows an active custom host's models* — open the picker with a
    saved `my-box.lan:8080` active and models in `available_models` → catalog
    mirrored `Ready`, rows present.
  - *non-active saved custom host gets a mergeable catalog* — open with
    Anthropic active and `api.my-gw.com` saved → catalog `Idle`, then a
    `FusedCatalogLoaded` merge yields rows.
  - Both tests **fail without the fix (7 assertions)** and pass with it
    (verified by stashing the fix and rebuilding).
- **Full suite:** 442/443 test cases green in the consolidated `agentty_tests`
  binary; the single failure (`classify_complexity buckets prompts`) is
  **pre-existing on clean HEAD** and unrelated (also verified by stashing).
- **Build:** compiles clean under the `dev` preset (`-Wall -Wextra -Wpedantic`),
  and `ctest --preset dev` shows no new failures.

## Notes for the maintainer

- The fused picker's sources (`provider_catalogs` + `fused_offers`) pre-date
  `cb5847aa` — the custom-host gap existed there earlier, but was invisible
  because the classic picker (which sourced `available_models` directly) was
  the default models menu. `cb5847aa` turned a latent gap into the reported
  regression. The fix is deliberately at the *source* layer, not the view, so
  Smart Mode slot-assign (which scopes the same rows to the active provider)
  also works for custom hosts.
- A custom host that happens to name an `oauth_native` host (e.g. a user adds
  `api.githubcopilot.com` directly) is *adopted* by that registry row in
  `parse_selection` — its identity, endpoint, and catalog mechanism all follow
  the adopted row. Such a spec still gets a catalog under its own spec string
  here (fetched through the same adopted path), which is correct: the fused
  list shows it under the name the user saved.
