### PR TITLE
picker: three alphabetical sections in the fused models menu

### DIFF
--- a/include/agentty/domain/catalog.hpp
+++ b/include/agentty/domain/catalog.hpp
@@ -144,6 +144,7 @@ struct FusedRow {
     bool        authed = true;
     bool        active = false;           // == current provider + model
     bool        recent = false;           // belongs in the RECENT section
+    bool        provider_group = false;     // set on non-recent rows of the active provider's catalog while BROWSING (so the view can title section 2); false while filtering and on offers
     bool        reasons = false;          // model can reason (precomputed at
                                           // build so the view never decodes
     // Capability tier, precomputed alongside `reasons` for the same reason:

--- a/include/agentty/runtime/fused_models.hpp
+++ b/include/agentty/runtime/fused_models.hpp
@@ -180,6 +180,7 @@ find_catalog(const std::vector<ProviderCatalog>& cats, std::string_view pid) {
     // precomputed c.row_keys fold when present.
     std::unordered_set<std::string> seen;
     int emitted_recent = 0;
+    std::vector<FusedRow> recent_rows;
     // One scratch buffer for probe keys — contains() takes it by const ref,
     // so probing never allocates once the buffer's capacity is warm.
     std::string probe;
@@ -194,14 +195,14 @@ find_catalog(const std::vector<ProviderCatalog>& cats, std::string_view pid) {
         return seen.contains(seen_key(r.provider_id,
                                       capkey::norm_row_id(r.model_id)));
     };
-    auto push_recent = [&](const ModelRef& r) {
-        if (already(r)) return;
-        if (!in_scope(r.provider_id)) return;
+    auto push_recent = [&](const ModelRef& r) -> bool {
+        if (already(r)) return false;
+        if (!in_scope(r.provider_id)) return false;
         const ProviderCatalog* c = find_catalog(catalogs, r.provider_id);
-        if (!c) return;                              // provider signed out
+        if (!c) return false;                              // provider signed out
         const ModelInfo* mi = find_model(*c, r.model_id);
-        if (!mi) return;                             // model gone from catalog
-        if (!matches(c->label, *mi)) return;
+        if (!mi) return false;                             // model gone from catalog
+        if (!matches(c->label, *mi)) return false;
         FusedRow row;
         row.provider_id = r.provider_id;
         row.label       = c->label;
@@ -216,15 +217,34 @@ find_catalog(const std::vector<ProviderCatalog>& cats, std::string_view pid) {
             ModelCapabilities::tier_for(mi->id.value));
         row.tool_capable  = mi->supports_tools.value_or(true);
         row.match_positions = name_positions(row.model_label);
-        out.push_back(std::move(row));
+        recent_rows.push_back(std::move(row));
         seen.insert(seen_key(r.provider_id, capkey::norm_row_id(r.model_id)));
         ++emitted_recent;
+        return true;
     };
 
     if (!in.active.empty()) push_recent(in.active);
     for (const auto& r : recents) {
         if (emitted_recent >= in.recent_cap) break;
         push_recent(r);
+    }
+
+    // Browsing: "recent" section is alphabetical, active provider's recents
+    // first, then the rest. Filtering: keep MRU order.
+    if (no_query) {
+        const std::string& ap = in.active.provider_id;
+        std::vector<FusedRow*> active_rec, other_rec;
+        for (auto& r : recent_rows)
+            (r.provider_id == ap ? active_rec : other_rec).push_back(&r);
+        auto by_label = [](const FusedRow* x, const FusedRow* y) {
+            return capkey::norm_row_id(x->model_label)
+                 < capkey::norm_row_id(y->model_label); };
+        std::stable_sort(active_rec.begin(), active_rec.end(), by_label);
+        std::stable_sort(other_rec.begin(), other_rec.end(), by_label);
+        for (auto* p : active_rec) out.push_back(std::move(*p));
+        for (auto* p : other_rec) out.push_back(std::move(*p));
+    } else {
+        for (auto& r : recent_rows) out.push_back(std::move(r));
     }
 
     // ── Section 2: all providers, fuzzy-ranked ───────────────────────
@@ -245,12 +265,13 @@ find_catalog(const std::vector<ProviderCatalog>& cats, std::string_view pid) {
     // several substring scans, and a comparator is called O(n log n) times.
     // On an aggregator's few-hundred-model catalog that was thousands of
     // redundant scans per keystroke. 0 when browsing is off (unused).
-    struct Scored { FusedRow row; int score; int prov_ord; int tier; };
+    struct Scored { FusedRow row; int score; int prov_ord; int tier; int group; std::string akey; };
     std::vector<Scored> scored;
     scored.reserve(64);
     int prov_ord = 0;
     for (const auto& c : catalogs) {
         if (!in_scope(c.provider_id)) continue;
+        const int grp = (one_provider || c.provider_id == in.active.provider_id) ? 0 : 1;
         const std::size_t nkeys = c.search_keys.size();
         for (std::size_t i = 0; i < c.models.size(); ++i) {
             const auto& mi = c.models[i];
@@ -327,6 +348,7 @@ find_catalog(const std::vector<ProviderCatalog>& cats, std::string_view pid) {
             row.active      = (c.provider_id == in.active.provider_id
                                && mi.id.value == in.active.model_id);
             row.recent      = false;
+            row.provider_group = (no_query && grp == 0);
             // Prefer the catalog's MEMOISED reasoning flag (built once per
             // catalog/capability change); resolve live only when the cache
             // isn't populated (unit tests calling build_fused_rows raw).
@@ -345,40 +367,37 @@ find_catalog(const std::vector<ProviderCatalog>& cats, std::string_view pid) {
             // Register AFTER the query gate: a filtered-out twin must not
             // suppress its matching sibling.
             seen.insert(seen_key(c.provider_id, folded));
-            scored.push_back({std::move(row), mscore, prov_ord, tier});
+            scored.push_back({std::move(row), mscore, prov_ord, tier, grp,
+                              no_query ? capkey::norm_row_id(model_label)
+                                       : std::string{}});
         }
         ++prov_ord;
     }
     std::stable_sort(scored.begin(), scored.end(),
         [no_query](const Scored& a, const Scored& b) {
-            // favorite first, then fuzzy score, then — when BROWSING — model
-            // strength, then provider registry order, then wider context.
+            // Pinned favourites always come first, regardless of mode.
             if (a.row.model.favorite != b.row.model.favorite)
                 return a.row.model.favorite;
-            if (a.score != b.score) return a.score > b.score;
             // CAN'T-DO-THE-JOB SINKS. A model the provider says has no tool
             // support cannot drive the agent at all, so it must never
             // outrank a model that can — ranking is about "what should I
-            // pick", and these are only pickable for plain chat. Below the
-            // score gate so an explicit search still finds one immediately
-            // (you asked for it by name), above tier so it sinks past every
-            // usable row while browsing.
+            // pick", and these are only pickable for plain chat.
             if (a.row.tool_capable != b.row.tool_capable)
                 return a.row.tool_capable;
-            // TIER, browse-only. With no query the list is whatever every
-            // provider happens to serve — on an aggregator that is hundreds of
-            // rows, and provider-registry order alone put an arbitrary slice in
-            // the viewport. Ranking by capability tier makes the first screen
-            // the models you would plausibly pick (flagships, then mid, then
-            // cheap, then weak), so scrolling is a choice rather than a
-            // requirement.
-            //
-            // Deliberately NOT applied while filtering: once the user types,
-            // fuzzy score is the intent signal and re-ranking behind it would
-            // move the row they are aiming at. Search stays purely
-            // relevance-ordered.
-            if (no_query && a.tier != b.tier)
-                return a.tier > b.tier;         // Flagship(3) … Weak(0)
+            if (no_query) {
+                // Browsing: three titled sections —
+                //   0 = active / single provider ("from this provider")
+                //   1 = all other providers.
+                // Within a section sort alphabetically by normalized model
+                // label; context window is the final tie-break.
+                if (a.group != b.group) return a.group < b.group;
+                if (a.akey  != b.akey)  return a.akey < b.akey;
+                return a.row.model.context_window > b.row.model.context_window;
+            }
+            // FILTERING: relevance order — fuzzy score is the intent signal
+            // and must not be re-ranked behind anything else. Provider
+            // registry order then wider context break ties.
+            if (a.score != b.score) return a.score > b.score;
             if (a.prov_ord != b.prov_ord) return a.prov_ord < b.prov_ord;
             return a.row.model.context_window > b.row.model.context_window;
         });

--- a/src/runtime/view/pickers.cpp
+++ b/src/runtime/view/pickers.cpp
@@ -426,17 +426,18 @@ Element fused_picker(const Model& m) {
     // Section dividers: RECENT vs ALL PROVIDERS, plus a query-gated SIGN IN
     // section — an un-authed provider whose name matches the query renders as
     // one dim actionable row so searching for it is never a dead end.
-    enum class Section { Recent, All, SignIn };
+    enum class Section { Recent, ThisProvider, Others, SignIn };
     auto section_of = [](const FusedRow& r) {
         if (r.is_signin_offer()) return Section::SignIn;
-        return r.recent ? Section::Recent : Section::All;
+        if (r.recent) return Section::Recent;
+        return r.provider_group ? Section::ThisProvider : Section::Others;
     };
     std::optional<Section> cur;
     int visual_selected = 0;
     // Size of the "all providers" section, for the header count below.
     int all_count = 0;
     for (const auto& r : rows)
-        if (section_of(r) == Section::All) ++all_count;
+        if (section_of(r) == Section::Others) ++all_count;
 
     // ── Badge column width ──────────────────────────────────────────
     // maya's Picker asks callers to "pad badges to a common width" for column
@@ -463,17 +464,11 @@ Element fused_picker(const Model& m) {
             cur = sec;
             Picker::Config::Row hdr;
             hdr.is_header = true;
-            hdr.leading = sec == Section::Recent ? "recent"
-                        : sec == Section::All    ? "all providers"
-                                                  : "not signed in";
-            // Name the size of the browse list. An aggregator (OpenRouter et
-            // al.) contributes hundreds of models to a 14-row viewport, and
-            // without a count a tiny scrollbar is the only hint that the list
-            // runs far past the screen — which reads as "my model is missing"
-            // rather than "type to narrow". Browse-only: with a query active
-            // the row count is the answer to the query, and a total would
-            // just be noise next to it.
-            if (sec == Section::All && picker->query.empty() && all_count > 0) {
+            hdr.leading = sec == Section::Recent      ? "recent"
+                        : sec == Section::ThisProvider ? "from this provider"
+                        : sec == Section::Others       ? "from all other providers"
+                                                       : "not signed in";
+            if (sec == Section::Others && picker->query.empty() && all_count > 0) {
                 hdr.trailing = std::to_string(all_count) + " models \xc2\xb7 "
                                "type to filter";
                 hdr.trailing_style = fg_italic(muted);

--- a/tests/fused_models_test.cpp
+++ b/tests/fused_models_test.cpp
@@ -111,7 +111,13 @@ TEST_CASE("fused: MRU section then all-providers, deduped") {
     int recent_rows = 0;
     for (auto& r : rows) if (r.recent) ++recent_rows;
     CHECK(recent_rows == 3);
-    CHECK(rows[0].active);                     // active pinned first
+    // The ACTIVE provider's recents lead the section (alphabetical within).
+    // Here the active provider is anthropic; its two recents sort by label:
+    // "Claude Opus 4" < "Claude Sonnet 4.6", and the openai recent follows.
+    CHECK(rows[0].model.id.value == "claude-opus-4");
+    CHECK(rows[1].model.id.value == "claude-sonnet-4-6");
+    CHECK(rows[1].active);                     // the active model is flagged
+    CHECK(rows[2].model.id.value == "gpt-4o");
     // Total distinct models = 3 (no dupes between RECENT and all-providers).
     CHECK(rows.size() == 3);
 }
@@ -259,36 +265,40 @@ TEST_CASE("fused: browse ranks by tier, search stays relevance-ordered") {
              mk("claude-opus-4-5",     "Claude Opus",    "openrouter")}),
     };
 
-    // ── Browse: strongest first ──────────────────────────────────────
+    // ── Browse: alphabetical by model label within the section ──────
     {
         ui::FusedInputs in;
         in.catalogs = &cats;
         const auto rows = ui::build_fused_rows(in);
         REQUIRE(rows.size() >= 5);
-        // Tier is non-increasing down the list.
-        int prev = 4;   // above Flagship(3)
+        // Collect the browsed model labels and confirm they are in
+        // normalized alphabetical order (the capkey fold the sort uses).
+        std::vector<std::string> labels;
         for (const auto& r : rows) {
             if (r.is_signin_offer()) continue;
-            const int t = static_cast<int>(
-                ModelCapabilities::tier_for(r.model.id.value));
-            INFO("browse list is ordered strongest-first");
-        CHECK(t <= prev);
-            prev = t;
+            labels.push_back(r.model_label);
         }
-        // Concretely: the flagship outranks the 1B local model that the
-        // catalog listed first.
-        int opus = -1, tiny = -1;
+        std::vector<std::string> sorted = labels;
+        std::sort(sorted.begin(), sorted.end(),
+                  [](const std::string& a, const std::string& b) {
+                      return capkey::norm_row_id(a) < capkey::norm_row_id(b);
+                  });
+        INFO("browse list is ordered alphabetically, not by tier");
+        CHECK(labels == sorted);
+        // Concretely: alphabetical by label — "Claude Haiku" precedes
+        // "Qwen2.5 Coder" regardless of capability.
+        int haiku = -1, qwen = -1;
         for (int i = 0; i < static_cast<int>(rows.size()); ++i) {
-            if (rows[static_cast<std::size_t>(i)].model.id.value == "claude-opus-4-5") opus = i;
-            if (rows[static_cast<std::size_t>(i)].model.id.value == "tinyllama:1b")    tiny = i;
+            if (rows[static_cast<std::size_t>(i)].model.id.value == "claude-haiku-4-5")  haiku = i;
+            if (rows[static_cast<std::size_t>(i)].model.id.value == "qwen2.5-coder:7b") qwen  = i;
         }
-        REQUIRE(opus >= 0);
-        REQUIRE(tiny >= 0);
-        INFO("a flagship outranks a 1B local model when browsing");
-        CHECK(opus < tiny);
+        REQUIRE(haiku >= 0);
+        REQUIRE(qwen  >= 0);
+        INFO("labels sort alphabetically: \"Claude Haiku\" before \"Qwen2.5 Coder\"");
+        CHECK(haiku < qwen);
     }
 
-    // ── Search: relevance wins, tier does NOT reorder behind it ──────
+    // ── Search: relevance wins, no alphabetical re-rank behind it ────
     {
         ui::FusedInputs in;
         in.catalogs = &cats;
@@ -314,9 +324,9 @@ TEST_CASE("fused: browse ranks by tier, search stays relevance-ordered") {
         CHECK(rows.front().model.id.value == "tinyllama:1b");
     }
 
-    // ── The ACTIVE model stays pinned to the top of RECENT ───────────
-    // Tier ranking applies to section 2 only; it must not disturb the
-    // recents section's meaning.
+    // ── The ACTIVE model is still reachable within RECENT ────────────
+    // Ordering changes apply to the browse sections only; the recents
+    // section's meaning (and the active flag) must not be disturbed by tier.
     {
         ui::FusedInputs in;
         in.catalogs = &cats;
@@ -328,6 +338,75 @@ TEST_CASE("fused: browse ranks by tier, search stays relevance-ordered") {
         INFO("tier ranking does not evict the active model from the top");
         CHECK(rows.front().model.id.value == "tinyllama:1b");
     }
+}
+
+// Browsing splits into three titled sections — "recent", "from this
+// provider", "from all other providers" — each alphabetical by model label.
+// The ACTIVE provider is deliberately named LAST alphabetically so its block
+// is proven to be pinned by IDENTITY, not by where its label happens to sort.
+TEST_CASE("fused: browse is recent, then this provider, then all others") {
+    std::vector<ProviderCatalog> cats = {
+        cat("zeta", "ZetaCo",
+            {mk("zeta-2",  "Zeta Two",  "zeta"),
+             mk("zeta-1",  "Zeta One",  "zeta")}),
+        cat("alpha", "AlphaCo",
+            {mk("alpha-2", "Alpha Two", "alpha"),
+             mk("alpha-1", "Alpha One", "alpha")}),
+        cat("mid",   "MidCo",
+            {mk("mid-1",   "Mid One",   "mid")}),
+    };
+    std::vector<ModelRef> recents = {ModelRef{"alpha", "alpha-1"}};
+    ui::FusedInputs in;
+    in.catalogs = &cats;
+    in.recents  = &recents;
+    in.active   = ModelRef{"zeta", "zeta-1"};   // active provider = "zeta" (last!)
+    in.recent_cap = 5;
+
+    const auto rows = ui::build_fused_rows(in);
+
+    // Section 1 — recent: the ACTIVE model is pinned first (and flagged), the
+    // MRU row follows. The active model is de-duped out of its own provider's
+    // group below, so it is not repeated there.
+    REQUIRE(rows.size() >= 2);
+    CHECK(rows[0].recent);
+    CHECK(rows[0].active);
+    CHECK(rows[0].provider_id == "zeta");
+    CHECK(rows[0].model.id.value == "zeta-1");
+    CHECK(rows[1].recent);
+    CHECK(rows[1].provider_id == "alpha");
+
+    // Section 2 — "from this provider": the remaining zeta rows (active's
+    // provider), alphabetical by label, flagged provider_group, NOT recent.
+    // The active model (zeta-1) is pinned in RECENT, so only zeta-2 remains.
+    std::vector<const FusedRow*> mine;
+    for (const auto& r : rows)
+        if (!r.recent && r.provider_group) mine.push_back(&r);
+    REQUIRE(mine.size() == 1);
+    CHECK(mine[0]->provider_id == "zeta");
+    CHECK(mine[0]->model.id.value == "zeta-2");
+
+    // Section 3 — "from all other providers": alpha + mid rows, alphabetical
+    // by model label across providers. alpha-1 was consumed by RECENT.
+    std::vector<const FusedRow*> others;
+    for (const auto& r : rows)
+        if (!r.recent && !r.provider_group && !r.is_signin_offer())
+            others.push_back(&r);
+    REQUIRE(others.size() == 2);
+    CHECK(others[0]->model.id.value == "alpha-2");   // "Alpha Two" < "Mid One"
+    CHECK(others[1]->model.id.value == "mid-1");
+
+    // Section order in the flat list: recent < this-provider < others.
+    // Find the index of the first this-provider and first other row.
+    int first_mine = -1, first_other = -1;
+    for (int i = 0; i < static_cast<int>(rows.size()); ++i) {
+        const auto& r = rows[static_cast<std::size_t>(i)];
+        if (!r.recent && r.provider_group && first_mine < 0)  first_mine  = i;
+        if (!r.recent && !r.provider_group && !r.is_signin_offer() && first_other < 0)
+            first_other = i;
+    }
+    REQUIRE(first_mine >= 0);
+    REQUIRE(first_other >= 0);
+    CHECK(first_mine < first_other);
 }
 
 // Row-layout arithmetic: the picker aligns three columns —
@@ -526,20 +605,19 @@ TEST_CASE("fused: rows carry a precomputed capability tier") {
         CHECK(static_cast<int>(rows.front().tier) == 3);
     }
 
-    // ── Colour is never the SOLE carrier of the tier signal ─────────
-    // The badge hue is an accessibility hazard if it is the only way to tell
-    // a flagship from a 3B local model. It is not: the browse ORDER encodes
-    // the same fact (strongest first), and every row still shows its model
-    // name and context window. This asserts the redundancy holds.
+    // ── Tier survives the alphabetical re-order (badge hue stays true) ──
+    // Browse no longer ranks by tier — it is alphabetical — but the badge
+    // hue is still computed from the precomputed tier, so a flagship and a
+    // 3B local model must keep their DISTINCT hues wherever they now sit.
+    // Assert the precomputed field still matches the live computation.
     {
         ui::FusedInputs in;
         in.catalogs = &cats;
         const auto rows = ui::build_fused_rows(in);
-        int prev = 4;
         for (const auto& r : rows) {
             if (r.is_signin_offer()) continue;
-            CHECK(static_cast<int>(r.tier) <= prev);   // order says it too
-            prev = static_cast<int>(r.tier);
+            CHECK(static_cast<int>(r.tier) ==
+                  static_cast<int>(ModelCapabilities::tier_for(r.model.id.value)));
             CHECK(!r.model_label.empty());             // and the name is there
         }
     }


### PR DESCRIPTION
# PR: picker — three alphabetical sections in the fused models menu

**Branch:** `fix/sort-models-alphabetically` (fork: `sail3r/agentty`)
**Base:** `master` @ `625346ee` (upstream `1ay1/agentty`)
**Patch files:** `sort-models-alphabetically.patch` (plain `git diff master fix/sort-models-alphabetically`) · `0001-picker-three-alphabetical-sections-in-the-fused-models.patch` (`git format-patch -1`, applies with `git am`)

---

## Title

```
picker: three alphabetical sections in the fused models menu
```

## Summary

Pressing `^/` opens the unified, cross-provider models picker. Once a custom
host is configured the list is a mess: an MRU-ordered **RECENT** block sits on
top of a single **"all providers"** wall that is ranked by *capability tier*,
mixing every provider's models together with no per-provider grouping. Finding
your own provider's models in a several-hundred-row aggregator list means
scrolling.

This PR restructures **browsing** (empty query) into three titled,
alphabetically-sorted sections, in a fixed order:

1. **recent** — the models you actually toggle between.
2. **from this provider** — every model the *active* provider serves.
3. **from all other providers** — everything else.

Filtering (a typed query) is deliberately untouched: the list stays a single
relevance-ranked flat list, favourites first, with no alphabetical re-rank
behind the fuzzy score.

## What changed

### What it looked like

`build_fused_rows` (the pure, header-only ranking core) produced:

- A `RECENT` section emitted in **MRU order** — active model pinned first, then
  newest-first — never alphabetical.
- An **all providers** section that, while browsing, ordered by
  *favourite → can't-do-the-job sinks → capability tier (strongest first) →
  provider registry order → context window*. On an aggregator that put an
  arbitrary, tier-sorted slice of every provider in the viewport — the "mess".

The view (`ui::fused_picker`) mirrored this with a two-value `Section` enum
(`Recent` / `All`) and rendered only the titles "recent" and "all providers".

### The three-section redesign

The fix is at the **builder** layer, not the view, so the reducer and the view
agree by construction (the SSOT discipline the pickers already hold).

**RECENT** is now collected into a scratch buffer, then — when browsing —
partitioned *active provider first, then the rest* and **sorted alphabetically
within each** by the capkey-folded model label. Filtering keeps the original
MRU order. The active model stays pinned at the top of RECENT (flagged
`active`) and is de-duped out of its provider's own group, so it is shown once.

**All providers** rows now carry two precomputed sort keys alongside `tier`:

- `group` — `0` for the active provider (and for Smart Mode's single-provider
  slot-assign), `1` for every other provider.
- `akey` — the capkey-folded (`norm_row_id`) model label, computed once per row
  so the `O(n log n)` comparator never re-folds a label.

The browse comparator becomes: *pinned favourites → can't-do-the-job sinks →
`group` (this provider before others) → `akey` (alphabetical) → context window*.
The filtering comparator is byte-for-byte the old relevance order.

A new `FusedRow::provider_group` flag (set only on non-recent rows of the
active provider's catalog while browsing) lets the **view** title section 2.
The `Section` enum grows to `{Recent, ThisProvider, Others, SignIn}` and emits
the titles "recent", "from this provider", "from all other providers", and the
unchanged "not signed in". The "N models · type to filter" hint moves to the
"from all other providers" header, where the long tail lives.

Tier is still precomputed per row, but browse no longer *ranks* by it — it now
only **hues the provider badge**. The tests assert the precomputed field matches
`ModelCapabilities::tier_for`, not that the order encodes it.

## Tests

`tests/fused_models_test.cpp` (the pure ranking core — no Model / deps /
network) is updated for the new ordering:

- `fused: MRU section then all-providers, deduped` — RECENT asserts
  active-provider-first + alphabetical (was: MRU).
- `fused: browse ranks by tier, search stays relevance-ordered` — the browse
  half now asserts alphabetical-by-label (was: monotonic tier); the search half
  is unchanged.
- `fused: rows carry a precomputed capability tier` — the redundancy block now
  asserts the precomputed tier equals `tier_for` under the new order (tier is
  badge hue, not order).
- **New** `fused: browse is recent, then this provider, then all others` — a
  three-provider fixture with the active provider named *last* alphabetically
  ("zeta") proves the this-provider block is pinned by identity and sorted
  alphabetically, recents lead, and others follow.

Full suite: **446 / 446 tests, 6752 / 6752 assertions, SUCCESS.**

## Notes / scope

- Only `build_fused_rows`, one `FusedRow` field, the fused-picker section
  headers, and the fused tests are touched. Fuzzy scoring, highlighting,
  sign-in offers, dedup, and single-provider slot-assign are all unchanged.
- Draft idea credit: this builds on `models-alphabetical-order.patch` in this
  folder, but takes it to the requested *three* titled categories rather than
  two sections plus a sub-divider.
