### PR TITLE
Add AGENTTY_MAX_SKILLS env knob to override the skill catalog cap

### DIFF
--- a/README.md
+++ b/README.md
@@ -382,6 +382,8 @@ your platform can't run offers edit/copy instead, and capture is capped at
 
 Drop a `SKILL.md` anywhere under `.agentty/skills/` or `~/.agentty/skills/` — it's live next turn. Compatible with Claude Code's `.claude/skills/` format.
 
+The tier-1 catalog (name + description of every discovered skill) is capped at 64 entries. Set `AGENTTY_MAX_SKILLS` to override it (clamped to 8–4096) — lower it for small-context models, raise it for large skill libraries.
+
 On codebases with internal DSLs or tribal conventions, agent accuracy jumps from ~20% to ~85% with curated skills ([research](https://arxiv.org/abs/2410.03981)).
 
 </details>

--- a/docs/website/environment.md
+++ b/docs/website/environment.md
@@ -43,6 +43,7 @@ channel list and line format.
 | `AGENTTY_OLLAMA_HOST` | Ollama base URL. Default `http://localhost:11434`. |
 | `AGENTTY_OLLAMA_NUM_CTX` · `AGENTTY_OLLAMA_NUM_PREDICT` · `AGENTTY_OLLAMA_TEMPERATURE` | Override Ollama's context window, output cap, and sampling temperature. Otherwise agentty picks per model. |
 | `AGENTTY_MAX_OUTPUT_TOKENS` | Cap `max_tokens` on every request (mirrors Claude Code's knob). Useful against a provider that rejects large output budgets. |
+| `AGENTTY_MAX_SKILLS` | Override the tier-1 skill catalog cap (default 64, clamped to 8–4096). Lower it for small-context models, raise it for large skill libraries. |
 | `AGENTTY_FORCE_EFFORT` | Force a reasoning-effort tier for every turn, overriding what the model's capabilities imply. For A/B-ing effort, not everyday use. |
 | `AGENTTY_CHATGPT_DEVICE_AUTH` | Use the device-code flow for ChatGPT sign-in instead of the loopback browser flow — for headless or remote machines. |
 | `AGENTTY_NO_PREWARM` | Skip the TLS/connection prewarm at startup. |

--- a/include/agentty/tool/skills.hpp
+++ b/include/agentty/tool/skills.hpp
@@ -98,7 +98,9 @@ struct Skill {
 };
 
 // Discover + parse every skill under the project + user roots. Bounded:
-// at most kMaxSkills entries, each body capped at kMaxBodyBytes. Result
+// at most the catalog cap (kMaxSkills by default; the AGENTTY_MAX_SKILLS
+// env var overrides it per discovery pass — see catalog_cap() in
+// skills.cpp), each body capped at kMaxBodyBytes. Result
 // is cached process-wide keyed by the roots' AND each SKILL.md's mtime
 // (an in-place edit to a skill is picked up next turn). Project skills
 // shadow user skills with the same name.

--- a/src/tool/skills.cpp
+++ b/src/tool/skills.cpp
@@ -7,9 +7,12 @@
 
 #include "agentty/scope/scope.hpp"
 #include "agentty/tool/util/fs_helpers.hpp"
+#include "agentty/util/dbglog.hpp"
 
 #include <algorithm>
+#include <charconv>
 #include <cstdio>
+#include <cstring>
 #include <filesystem>
 #include <fstream>
 #include <mutex>
@@ -21,6 +24,43 @@ namespace agentty::tools::skills {
 namespace fs = std::filesystem;
 
 namespace {
+
+// ── Catalog cap: default + env override ─────────────────────────────
+//
+// kMaxSkills (header) is the default tier-1 catalog cap;
+// AGENTTY_MAX_SKILLS overrides it — for small-context models (a
+// 100-skill library would eat the system prompt) or libraries that
+// legitimately exceed the default. Re-read on every call, not cached:
+// matches the house style of env knobs (bridge.cpp call_timeout et al.)
+// and keeps the knob testable. all() caches its result keyed on root +
+// file mtimes, so a mid-session env change takes effect on the next
+// rescan either way; real processes don't change env mid-session.
+//
+// Clamped to [8, 4096]: below 8 the catalog loses the trade that
+// motivated the cap (the listing is worth its context), above 4096 it
+// no longer protects the system prompt at all. A malformed value keeps
+// the default (matches bridge.cpp's env parsing) with a dbglog
+// breadcrumb.
+//
+// BOTH bound sites go through this — scan_root's candidate collection
+// and the catalog slice in all() — so a raised cap lifts the scan-side
+// WORK bound too; capping only the slice would truncate discovery of
+// large libraries (the bug scan_root's comment documents).
+[[nodiscard]] std::size_t catalog_cap() noexcept {
+    if (const char* e = std::getenv("AGENTTY_MAX_SKILLS"); e && e[0]) {
+        const char* end = e + std::strlen(e);
+        std::size_t v   = 0;
+        const auto [ptr, ec] = std::from_chars(e, end, v);
+        if (ec == std::errc{} && ptr == end) {
+            if (v < 8)    return std::size_t{8};
+            if (v > 4096) return std::size_t{4096};
+            return v;
+        }
+        agentty::util::dbglog("skills.catalog_cap.env",
+                              "AGENTTY_MAX_SKILLS: not a positive integer — using default");
+    }
+    return kMaxSkills;
+}
 
 [[nodiscard]] fs::path home_dir() noexcept {
     return agentty::util::home_dir_or_empty();
@@ -300,7 +340,7 @@ void scan_root(const fs::path& root, const std::string& source,
         // need visiting.
         if (it.depth() >= static_cast<int>(kMaxSkillDepth))
             it.disable_recursion_pending();
-        if (mds.size() >= kMaxSkills) break;
+        if (mds.size() >= catalog_cap()) break;
         if (it->is_directory(ec)) {
             auto fname = it->path().filename().string();
             if (!fname.empty() && fname.front() == '.') {
@@ -344,7 +384,7 @@ void scan_root(const fs::path& root, const std::string& source,
     mds.erase(std::unique(mds.begin(), mds.end()), mds.end());
 
     for (const auto& md : mds) {
-        if (out.size() >= kMaxSkills) break;
+        if (out.size() >= catalog_cap()) break;
         // Slug = path below the root, sanitized to the spec's charset. A
         // SKILL.md sitting directly in the root has no directory of its
         // own — same as the flat scan, it is not a skill (a skill is a

--- a/tests/skills_engine_test.cpp
+++ b/tests/skills_engine_test.cpp
@@ -413,3 +413,96 @@ TEST_CASE("skills engine") {
     fs::remove_all(base, ec);
 
 }
+
+TEST_CASE("skills catalog cap: AGENTTY_MAX_SKILLS override") {
+    agtest::ScopedEnvSandbox _env_guard;
+    std::error_code ec;
+    fs::path base = fs::temp_directory_path(ec) / "agentty_skills_cap_test";
+    fs::remove_all(base, ec);
+    fs::path home = base / "home";
+    fs::path work = base / "work";
+    fs::create_directories(home);
+    fs::create_directories(work);
+
+#if defined(_WIN32)
+    _putenv_s("HOME", home.string().c_str());
+    _putenv_s("AGENTTY_HOME", "");
+#else
+    setenv("HOME", home.string().c_str(), 1);
+    unsetenv("AGENTTY_HOME");
+#endif
+    fs::current_path(work);
+    util::set_workspace_root(work);
+
+    // The knob is read per discovery pass, and all() rescans only when its
+    // mtime signature changes — so each sub-case below shifts the sig by
+    // changing how many SKILL.md mtimes the (cap-bounded) walk collects.
+    // Adjacent sub-cases never share a signature while expecting different
+    // results, so no forced cache-buster writes are needed.
+
+    // RAII on the knob itself: restore (or clear) even if a CHECK throws.
+    const char* old_raw = std::getenv("AGENTTY_MAX_SKILLS");
+    const bool  had_old = old_raw != nullptr;
+    const std::string old_val = had_old ? old_raw : "";
+    struct Restore {
+        const bool had; const std::string val;
+        ~Restore() {
+#if defined(_WIN32)
+            if (had) _putenv_s("AGENTTY_MAX_SKILLS", val.c_str());
+            else     _putenv_s("AGENTTY_MAX_SKILLS", "");
+#else
+            if (had) setenv("AGENTTY_MAX_SKILLS", val.c_str(), 1);
+            else     unsetenv("AGENTTY_MAX_SKILLS");
+#endif
+        }
+    } _restore{had_old, old_val};
+
+    auto set_env = [](const char* v) {
+#if defined(_WIN32)
+        _putenv_s("AGENTTY_MAX_SKILLS", v);   // empty value removes (CRT)
+#else
+        setenv("AGENTTY_MAX_SKILLS", v, 1);
+#endif
+    };
+    auto unset_env = []() {
+#if defined(_WIN32)
+        _putenv_s("AGENTTY_MAX_SKILLS", "");
+#else
+        unsetenv("AGENTTY_MAX_SKILLS");
+#endif
+    };
+
+    // 80 skills — over the default cap in every scenario below.
+    constexpr std::size_t kSkills = 80;
+    for (std::size_t i = 0; i < kSkills; ++i) {
+        const std::string slug = "cap-skill-" + std::to_string(i);
+        write_file_at(home / ".agentty/skills" / slug / "SKILL.md",
+            "---\nname: " + slug + "\ndescription: cap test\n---\nB\n");
+    }
+
+    // ── Default (unset): kMaxSkills entries survive the walk AND the
+    // catalog slice — the cap applies to the WORK as well as the RESULT.
+    unset_env();
+    CHECK(skills::all().size() == skills::kMaxSkills);
+
+    // ── Raised: every discovered skill is catalogued, including the ones
+    // the default-capped walk never even visited.
+    set_env("200");
+    CHECK(skills::all().size() == kSkills);
+    CHECK(skills::find("cap-skill-79") != nullptr);
+
+    // ── Lowered: the catalog truncates to the override.
+    set_env("10");
+    CHECK(skills::all().size() == 10);
+
+    // ── Clamp floor: below the floor pins to it.
+    set_env("2");
+    CHECK(skills::all().size() == 8);
+
+    // ── Malformed: garbage keeps the default cap.
+    set_env("not-a-number");
+    CHECK(skills::all().size() == skills::kMaxSkills);
+
+    fs::current_path(base, ec);
+    fs::remove_all(base, ec);
+}


### PR DESCRIPTION
The tier-1 skill catalog (name + description of every discovered skill) was hard-capped at kMaxSkills = 64 with no way to tune it. Small-context models drown in a large library's listing; big curated libraries get silently truncated.

New: AGENTTY_MAX_SKILLS overrides the cap at discovery time, clamped to [8, 4096]; a malformed value keeps the default with a dbglog breadcrumb. The override feeds BOTH bound sites — scan_root's candidate collection and the catalog slice in all() — so a raised cap lifts the scan-side work bound too, not just the result (the failure mode scan_root's comment documents). Default behavior is unchanged.

Also: document the knob in docs/website/environment.md (next to AGENTTY_MAX_OUTPUT_TOKENS), the README Agent Skills block, and add a doctest TEST_CASE covering default/raised/lowered/clamped/malformed.