### PR TITLE
fix: remove dead wants_reasoning_text() helper

### DIFF
--- a/src/provider/copilot/provider.cpp
+++ b/src/provider/copilot/provider.cpp
@@ -146,20 +146,6 @@ std::set<std::string>& responses_only_set() {
     return responses_only_set().count(model) > 0;
 }
 
-// Does this model return reasoning TEXT on /responses?
-//
-// MEASURED against a live Auto session: gpt-5-* answers /responses with a
-// `reasoning` output item carrying real summary text (and streams
-// response.reasoning_summary_text.delta), while the same model on
-// /chat/completions returns none — which is the whole reason this fork
-// exists. Claude and GPT-4.x reject /responses outright, so they are never
-// candidates. Kept as a narrow prefix test rather than a hardcoded model
-// list so new gpt-5 spellings are picked up without a release; anything
-// wrong here degrades to "stay on chat", never to a broken turn.
-[[nodiscard]] bool wants_reasoning_text(const std::string& model) {
-    return model.rfind("gpt-5", 0) == 0;
-}
-
 // Which concrete model will the Auto session stream?
 //
 // ONE implementation, used by BOTH dialect paths — the Responses fork must


### PR DESCRIPTION
## Summary

The release build emits a `-Wunused-function` warning:

```
src/provider/copilot/provider.cpp:159:20: warning:
  'bool agentty::provider::copilot::{anonymous}::wants_reasoning_text(const std::string&)'
  defined but not used [-Wunused-function]
```

This is a leftover from the recent provider refactor (commit `f99b8320`,
"provider: make wire dialect a per-(provider,model) decision, not a row
field"). That refactor moved the "does this model emit reasoning summaries"
question into the shared `agentty::provider::dialect` module
(`model_emits_reasoning_summaries()` / `dialect_for()`), which superseded the
Copilot-local `wants_reasoning_text()` helper. The helper was left behind with
no remaining callers, so it is now dead code.

## Change

Remove the orphaned `wants_reasoning_text()` function (and its now-stale
comment block) from `src/provider/copilot/provider.cpp`. No behaviour changes:
the function had zero call sites, and its logic is already covered by the
shared dialect predicates.

## Verification

- `cmake --preset release` + full `ninja` build completes with **no warnings**
  (previously the `-Wunused-function` warning fired on every release build).
- The `agentty` binary links successfully.
