### PR TITLE
build: silence Release-mode warnings (dead code + _FORTIFY_SOURCE redefinition)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -23,6 +23,8 @@ include(AgenttySubmodules)
 # Per-domain source group lists (AGENTTY_*_SOURCES). See cmake/AgenttySources.cmake.
 include(AgenttySources)
 
+include(CheckCXXSourceCompiles)
+
 # ── Shared compile flags ────────────────────────────────────────────────
 # All agentty TUs (the main binary, the shared OBJECT libraries below, and
 # every test) MUST compile with byte-identical flags. The arch flag
@@ -607,8 +609,30 @@ if(NOT MSVC AND NOT AGENTTY_SANITIZE)
     endif()
     # _FORTIFY_SOURCE requires -O1+; only define it for optimizing configs so
     # a Debug build doesn't emit the "requires optimization" warning per TU.
-    target_compile_definitions(agentty PRIVATE
-        $<$<NOT:$<CONFIG:Debug>>:_FORTIFY_SOURCE=2>)
+    #
+    # A hardening toolchain spec or distro packager flags (e.g. Arch makepkg's
+    # `-D_FORTIFY_SOURCE=3` injected via CFLAGS) can already predefine
+    # _FORTIFY_SOURCE earlier on the command line. Adding our own -D after it
+    # trips GCC's "`_FORTIFY_SOURCE' redefined" warning on the only target
+    # carrying this def (`agentty`'s lone TU, src/runtime/main.cpp). Detect an
+    # injected definition at configure time and yield to it: the toolchain's
+    # value is already the packager's hardening choice, and skipping ours drops
+    # the redefinition warning with no functional loss. When nothing predefines
+    # the macro we add =2 exactly as before.
+    set(_agt_req_quiet_save ${CMAKE_REQUIRED_QUIET})
+    set(CMAKE_REQUIRED_QUIET YES)
+    check_cxx_source_compiles("
+        #ifndef _FORTIFY_SOURCE
+        #error _FORTIFY_SOURCE is not predefined by the toolchain
+        #endif
+        int main() { return 0; }
+    " AGENTTY_FORTIFY_PREDEFINED)
+    set(CMAKE_REQUIRED_QUIET ${_agt_req_quiet_save})
+    unset(_agt_req_quiet_save)
+    if(NOT AGENTTY_FORTIFY_PREDEFINED)
+        target_compile_definitions(agentty PRIVATE
+            $<$<NOT:$<CONFIG:Debug>>:_FORTIFY_SOURCE=2>)
+    endif()
     # A fully-static build already carries its own PIE decision (-static-pie
     # or -no-pie); adding a bare -pie here would fight it. Only add -pie for
     # the non-static path.

--- a/src/runtime/form.cpp
+++ b/src/runtime/form.cpp
@@ -109,13 +109,6 @@ void number_insert(field::Number& n, char32_t ch) {
     n.value = std::clamp(next, n.min, n.max);
 }
 
-[[nodiscard]] std::string lower(std::string_view s) {
-    std::string out;
-    out.reserve(s.size());
-    for (unsigned char c : s) out.push_back(static_cast<char>(std::tolower(c)));
-    return out;
-}
-
 // Keep the highlight inside the list, and the scroll window near it.
 //
 // This is a HINT. The real window is only knowable at paint time (it depends on

--- a/src/runtime/rag_settings_form.cpp
+++ b/src/runtime/rag_settings_form.cpp
@@ -59,7 +59,6 @@ void add_all_registry_rows(form::Builder& b, const store::Settings& settings,
 
 form::Form build_form(const eb::EmbedConfig& c, store::RagMode mode,
                       const store::Settings& settings, bool advanced) {
-    const store::RagConfig& rag = settings.rag;
     form::Builder b{" Retrieval "};
     b.subtitle(eb::describe(c));
 

--- a/src/runtime/view/pickers/model_picker.cpp
+++ b/src/runtime/view/pickers/model_picker.cpp
@@ -470,9 +470,7 @@ Element provider_picker(const Model& m) {
     };
 
     cfg.rows.reserve(rows.size());
-    int i = 0;
     for (const auto& r : rows) {
-        const bool sel = (i == picker->index);
         Panel::Row row;
 
         if (const auto* p = r.preset()) {
@@ -530,7 +528,6 @@ Element provider_picker(const Model& m) {
         // trailing cell matters more, like the file picker's diffstat.
         row.trailing_secondary = true;
         cfg.rows.push_back(std::move(row));
-        ++i;
     }
 
     // Enter opens the accounts drill-down on an account-capable OAuth

--- a/src/runtime/view/pickers/nav_pickers.cpp
+++ b/src/runtime/view/pickers/nav_pickers.cpp
@@ -35,7 +35,6 @@ Element thread_list(const Model& m) {
             fg_italic(muted)));
     } else {
         cfg.rows.reserve(m.d.threads.size());
-        int i = 0;
         for (const auto& t : m.d.threads) {
             const bool is_current = (t.id == m.d.current.id);
             const bool confirming = (picker->confirm_remove == t.id.value);
@@ -62,7 +61,6 @@ Element thread_list(const Model& m) {
             // data and yields first on a narrow terminal.
             row.trailing_secondary = true;
             cfg.rows.push_back(std::move(row));
-            ++i;
         }
     }
 


### PR DESCRIPTION
## Summary

Silences the five compiler warnings that surface in an optimizing
(`-DCMAKE_BUILD_TYPE=Release`) build, with no behavior change.

Four are dead code flagged by GCC's `-Wunused*` family (left behind by the
`ac7b6230` "one form layer for every config surface" settings refactor). The
fifth is a `_FORTIFY_SOURCE` command-line redefinition that only appears on
hardened/packaging toolchains that already inject the macro.

## Warnings addressed

| # | File | Warning | Fix |
|---|------|---------|-----|
| 1 | `src/runtime/form.cpp:112` | `lower()` defined but not used (`-Wunused-function`) | Remove the orphaned helper |
| 2 | `src/runtime/rag_settings_form.cpp:62` | unused variable `rag` (`-Wunused-variable`) | Remove the unused local alias |
| 3 | `src/runtime/view/pickers/model_picker.cpp:475` | unused variable `sel` (`-Wunused-variable`) | Remove `sel` (and the now-dead `i` counter) |
| 4 | `src/runtime/view/pickers/nav_pickers.cpp:38` | variable `i` set but not used (`-Wunused-but-set-variable`) | Remove the unread row counter |
| 5 | `<command-line>` (compiling `main.cpp.o`) | `'_FORTIFY_SOURCE' redefined` | Detect a toolchain-injected value at configure time and yield to it |

## Details

**1. `form.cpp` — unused `lower()`.** An anonymous-namespace helper
`lower(std::string_view)` was defined but had zero callers; the `ac7b6230`
refactor removed its uses. A byte-identical copy still lives in
`settings_registry.cpp` and is in active use there, so only the dead copy is
removed. (Nothing else in `form.cpp` uses `<cctype>`, but that include is left
untouched to keep the diff minimal and non-functional.)

**2. `rag_settings_form.cpp` — unused `rag`.** `const store::RagConfig& rag =
settings.rag;` was bound at the top of `build_form()` but never referenced —
every call site reads `settings.rag` directly. The alias is removed.

**3. `model_picker.cpp` (`provider_picker`) — unused `sel`.** `const bool sel =
(i == picker->index);` was computed for each row but never read; the active
state is derived inside the row from `p->id`/`active_id`. With `sel` gone, the
loop index `int i = 0; … ++i;` had no remaining reads either, so both are
removed.

**4. `nav_pickers.cpp` (`thread_list`) — set-but-unused `i`.** `int i = 0;` was
initialized and incremented per row (`++i;`) but never read anywhere in the
loop. Both lines are removed.

**5. `CMakeLists.txt` — `_FORTIFY_SOURCE` redefinition.** The project sets
`target_compile_definitions(agentty … _FORTIFY_SOURCE=2)`. Because it is
`PRIVATE` to the `agentty` target, it lands only on `src/runtime/main.cpp` —
the single TU that warned in the build log. GCC reports both the prior and the
new definition at `<command-line>`, which means the macro was *already defined
on the command line* before our `-D` — i.e. a hardening toolchain spec or a
distro packager (Arch makepkg injects `-D_FORTIFY_SOURCE=3` via `CFLAGS`, as
this repo's own CHANGELOG notes) predefined it. GCC warns about redefinition
only when the values differ. The fix runs a configure-time
`check_cxx_source_compiles` probe: if the toolchain already predefines
`_FORTIFY_SOURCE`, we keep its (packager-chosen, stronger-or-equal) value and
skip ours entirely; otherwise we add `=2` exactly as before.

## Verification

- **Release configure, clean toolchain:** `-D_FORTIFY_SOURCE=2` still present
  on `main.cpp.o`; no stray flags introduced.
- **Release configure, `CXXFLAGS=-D_FORTIFY_SOURCE=3` (simulating the hardened
  toolchain that produced `errors.md`):** `AGENTTY_FORTIFY_PREDEFINED=1`
  detected, our `=2` skipped, and `main.cpp.o` compiles with **no**
  `_FORTIFY_SOURCE redefined` warning.
- **Dev build (`cmake --preset dev`, `cmake --build build/dev`):** the four
  previously-warning TUs now compile with **zero** warnings/errors.
- **Tests:** `./build/dev/agentty_tests` → 446 cases, **445 passed / 1 failed**
  — byte-identical to the pre-fix baseline. The single failure is
  `pickers: primary labels are not dimmed, trailing yields first`
  (`tests/fused_models_test.cpp:649`, `REQUIRE(in.good())` — a golden-file
  fixture read), which fails identically on the untouched baseline (verified
  via `git stash`) and touches none of the modified files.

## Test plan

- `cmake --preset release && cmake --build build/release` — no warnings.
- `cmake --preset dev && cmake --build build/dev && ./build/dev/agentty_tests`
  — matches baseline.
